### PR TITLE
omit closing ansi code if no open codes were emitted

### DIFF
--- a/src/dyn_styles.rs
+++ b/src/dyn_styles.rs
@@ -348,7 +348,22 @@ macro_rules! impl_fmt {
 
                     <T as $trait>::fmt(&self.target, f)?;
 
-                    f.write_str("\x1b[0m")
+                    if s.fg.is_some()
+                        || s.bg.is_some()
+                        || s.bold
+                        || s.dimmed
+                        || s.italic
+                        || s.underline
+                        || s.blink
+                        || s.blink_fast
+                        || s.reversed
+                        || s.hidden
+                        || s.strikethrough
+                    {
+                        f.write_str("\x1b[0m")?;
+                    }
+
+                    Ok(())
                 }
             }
         )*


### PR DESCRIPTION
Prior to this commit whenever a `Default` style is used it will always emit the original text followed by what I can only assume is the "clear ansi flags" code. This PR changes the `Display` impl for `Style` to instead check if any codes were already emitted and skips the closing code if none were.