### PR TITLE
Add ability to conditionally apply styles if stdout/stderr is a tty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "owo-colors"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["jam1garner <8260240+jam1garner@users.noreply.github.com>"]
 edition = "2018"
 documentation = "https://docs.rs/owo-colors"
@@ -18,3 +18,6 @@ required-features = ["custom"]
 
 [features]
 custom = []
+
+[dependencies]
+atty = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,13 @@ all-features = true
 name = "custom_colors"
 required-features = ["custom"]
 
+[[example]]
+name = "is_tty"
+required-features = ["tty"]
+
 [features]
 custom = []
+tty = ["atty"]
 
 [dependencies]
-atty = "0.2.14"
+atty = { version = "0.2", optional = true }

--- a/examples/is_tty.rs
+++ b/examples/is_tty.rs
@@ -1,0 +1,5 @@
+use owo_colors::OwoColorize;
+
+fn main() {
+    println!("{}", "This will be red if viewed through a tty!".if_stdout_tty(|x| x.red()));
+}

--- a/src/dyn_styles.rs
+++ b/src/dyn_styles.rs
@@ -236,8 +236,8 @@ impl Style {
     }
 
     /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](crate::OwoColorize::fg) or
+    /// a color-specific method, such as [`OwoColorize::green`](crate::OwoColorize::green),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -252,8 +252,8 @@ impl Style {
     }
 
     /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](crate::OwoColorize::bg) or
+    /// a color-specific method, such as [`OwoColorize::on_yellow`](crate::OwoColorize::on_yellow),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -304,7 +304,7 @@ impl Style {
     }
 }
 
-/// Helper to create [Styles](dyn_styles::Style) more ergonomically
+/// Helper to create [`Style`]s more ergonomically
 pub fn style() -> Style {
     Style::new()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,12 @@ macro_rules! style_methods {
 /// * [`reversed`](OwoColorize::reversed)
 /// * [`hidden`](OwoColorize::hidden)
 /// * [`strikethrough`](OwoColorize::strikethrough)
+///
+/// **Do you want it to only display colors if it's a terminal?**
+///
+/// 1. Enable the `tty` feature
+/// 2. Colorize inside [`if_tty`](OwoColorize::if_tty)
+///
 pub trait OwoColorize: Sized {
     /// Set the foreground color generically
     ///
@@ -332,8 +338,17 @@ pub trait OwoColorize: Sized {
         BgDynColorDisplay(self, Rgb(r, g, b))
     }
 
+    /// Apply a runtime-determined style
     fn style(&self, style: Style) -> Styled<&Self> {
         style.style(self)
+    }
+    
+    fn if_stdout_tty<'a, Out, F: Fn(&'a Self) -> Out>(&'a self, apply: F) -> TtyDisplay<'a, StdOut, Self, Out, F> {
+        TtyDisplay(self, apply, StdOut)
+    }
+    
+    fn if_stderr_tty<'a, Out, F: Fn(&'a Self) -> Out>(&'a self, apply: F) -> TtyDisplay<'a, StdErr, Self, Out, F> {
+        TtyDisplay(self, apply, StdErr)
     }
 }
 
@@ -347,6 +362,11 @@ pub use dyn_colors::*;
 
 mod dyn_styles;
 pub use dyn_styles::*;
+
+mod tty_display;
+pub use tty_display::TtyDisplay;
+
+use tty_display::{StdOut, StdErr};
 
 /// Color types for used for being generic over the color
 pub mod colors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,8 @@ macro_rules! style_methods {
 /// **Do you want it to only display colors if it's a terminal?**
 ///
 /// 1. Enable the `tty` feature
-/// 2. Colorize inside [`if_tty`](OwoColorize::if_tty)
+/// 2. Colorize inside [`if_stdout_tty`](OwoColorize::if_stdout_tty) or
+/// [`if_stdout_tty`](OwoColorize::if_stderr_tty)
 ///
 pub trait OwoColorize: Sized {
     /// Set the foreground color generically
@@ -343,11 +344,64 @@ pub trait OwoColorize: Sized {
         style.style(self)
     }
     
-    fn if_stdout_tty<'a, Out, F: Fn(&'a Self) -> Out>(&'a self, apply: F) -> TtyDisplay<'a, StdOut, Self, Out, F> {
+    /// Apply a given transformation function to all formatters if stdout is a tty console
+    /// allowing you to conditionally apply given styles/colors.
+    ///
+    /// Requires the `tty` feature.
+    ///
+    /// ```rust
+    /// use owo_colors::{OwoColorize, Style};
+    ///
+    /// fn main() {
+    ///     println!(
+    ///         "{}",
+    ///         "bright cyan if this is terminal output"
+    ///             .if_stdout_tty(|text| text.bright_cyan())
+    ///     );
+    ///
+    ///     // applying multiple at both
+    ///     println!(
+    ///         "{}",
+    ///         "bright cyan AND underlined(?!) if this is terminal output"
+    ///             .if_stdout_tty(|text| text.style(
+    ///                 Style::new()
+    ///                     .bright_cyan()
+    ///                     .underline()
+    ///             ))
+    ///     );
+    /// }
+    /// ```
+    fn if_stdout_tty<'a, Out, ApplyFn>(
+        &'a self,
+        apply: ApplyFn
+    ) -> TtyDisplay<'a, StdOut, Self, Out, ApplyFn>
+        where ApplyFn: Fn(&'a Self) -> Out
+    {
         TtyDisplay(self, apply, StdOut)
     }
     
-    fn if_stderr_tty<'a, Out, F: Fn(&'a Self) -> Out>(&'a self, apply: F) -> TtyDisplay<'a, StdErr, Self, Out, F> {
+    /// Apply a given transformation function to all formatters if stderr is a tty console
+    /// allowing you to conditionally apply given styles/colors.
+    ///
+    /// Requires the `tty` feature.
+    ///
+    /// ```rust
+    /// use owo_colors::OwoColorize;
+    ///
+    /// fn main() {
+    ///     eprintln!(
+    ///         "{}",
+    ///         "woah! error! if this is terminal output, it's red"
+    ///             .if_stderr_tty(|text| text.bright_red())
+    ///     );
+    /// }
+    /// ```
+    fn if_stderr_tty<'a, Out, ApplyFn>(
+        &'a self,
+        apply: ApplyFn
+    ) -> TtyDisplay<'a, StdErr, Self, Out, ApplyFn>
+        where ApplyFn: Fn(&'a Self) -> Out
+    {
         TtyDisplay(self, apply, StdErr)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,7 @@ pub trait OwoColorize: Sized {
     ///     );
     /// }
     /// ```
+    #[cfg(feature = "tty")]
     fn if_stdout_tty<'a, Out, ApplyFn>(
         &'a self,
         apply: ApplyFn
@@ -396,6 +397,7 @@ pub trait OwoColorize: Sized {
     ///     );
     /// }
     /// ```
+    #[cfg(feature = "tty")]
     fn if_stderr_tty<'a, Out, ApplyFn>(
         &'a self,
         apply: ApplyFn
@@ -417,9 +419,13 @@ pub use dyn_colors::*;
 mod dyn_styles;
 pub use dyn_styles::*;
 
+#[cfg(feature = "tty")]
 mod tty_display;
+
+#[cfg(feature = "tty")]
 pub use tty_display::TtyDisplay;
 
+#[cfg(feature = "tty")]
 use tty_display::{StdOut, StdErr};
 
 /// Color types for used for being generic over the color

--- a/src/tty_display.rs
+++ b/src/tty_display.rs
@@ -3,6 +3,7 @@ use core::fmt;
 pub struct StdOut;
 pub struct StdErr;
 
+/// Trait implemented to provide fake const generics for plugging in given streams
 pub trait IsTty {
     const TTY: atty::Stream;
 }
@@ -15,8 +16,16 @@ impl IsTty for StdErr {
     const TTY: atty::Stream = atty::Stream::Stderr;
 }
 
-pub struct TtyDisplay
-    <'a, Tty: IsTty,  In: ?Sized, Out, F: Fn(&'a In) -> Out>(pub(crate) &'a In, pub(crate) F, pub(crate) Tty);
+/// A display which applies a transformation based on if the given stream is a tty
+pub struct TtyDisplay<'a, Tty,  InVal, Out, ApplyFn>
+(
+    pub(crate) &'a InVal,
+    pub(crate) ApplyFn,
+    pub(crate) Tty
+) 
+  where Tty: IsTty,
+        InVal: ?Sized,
+        ApplyFn: Fn(&'a InVal) -> Out;
 
 macro_rules! impl_fmt_for {
     ($($trait:path),* $(,)?) => {

--- a/src/tty_display.rs
+++ b/src/tty_display.rs
@@ -1,0 +1,48 @@
+use core::fmt;
+
+pub struct StdOut;
+pub struct StdErr;
+
+pub trait IsTty {
+    const TTY: atty::Stream;
+}
+
+impl IsTty for StdOut {
+    const TTY: atty::Stream = atty::Stream::Stdout;
+}
+
+impl IsTty for StdErr {
+    const TTY: atty::Stream = atty::Stream::Stderr;
+}
+
+pub struct TtyDisplay
+    <'a, Tty: IsTty,  In: ?Sized, Out, F: Fn(&'a In) -> Out>(pub(crate) &'a In, pub(crate) F, pub(crate) Tty);
+
+macro_rules! impl_fmt_for {
+    ($($trait:path),* $(,)?) => {
+        $(
+            impl<'a, Tty: IsTty, In: $trait, Out: $trait, F: Fn(&'a In) -> Out> $trait for TtyDisplay<'a, Tty, In, Out, F> {
+                #[inline(always)]
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    if atty::is(Tty::TTY) {
+                        <Out as $trait>::fmt(&self.1(self.0), f)
+                    } else {
+                        <In as $trait>::fmt(self.0, f)
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_fmt_for! {
+    fmt::Display,
+    fmt::Debug,
+    fmt::UpperHex,
+    fmt::LowerHex,
+    fmt::Binary,
+    fmt::UpperExp,
+    fmt::LowerExp,
+    fmt::Octal,
+    fmt::Pointer,
+}


### PR DESCRIPTION
Also bumping to 1.3.0

Example from the docs:

```rust
use owo_colors::{OwoColorize, Style};

fn main() {
    println!(
        "{}",
        "bright cyan if this is terminal output"
            .if_stdout_tty(|text| text.bright_cyan())
    );

    // applying multiple at both
    println!(
        "{}",
        "bright cyan AND underlined(?!) if this is terminal output"
            .if_stdout_tty(|text| text.style(
                Style::new()
                    .bright_cyan()
                    .underline()
            ))
    );
}
```