### PR TITLE
[WIP] NO_COLOR prototype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ name = "is_tty"
 required-features = ["tty"]
 
 [features]
+env-no-color = []
+no-color = []
 tty = ["atty"]
 
 # outdated feature, does nothing

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -23,6 +23,7 @@ macro_rules! colors {
             }
 
             impl crate::DynColor for AnsiColors {
+                #[cfg(not(feature = "no-color"))]
                 fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let color = match self {
                         $(
@@ -30,9 +31,23 @@ macro_rules! colors {
                         )*
                     };
 
+                    #[cfg(feature = "env-no-color")]
+                    if std::env::var("NO_COLOR").is_ok() {
+                        write!(f, "{}", color)
+                    } else {
+                        Ok(())
+                    }
+
+                    #[cfg(not(feature = "env-no-color"))]
                     write!(f, "{}", color)
                 }
 
+                #[cfg(feature = "no-color")]
+                fn fmt_ansi_fg(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    Ok(())
+                }
+
+                #[cfg(not(feature = "no-color"))]
                 fn fmt_ansi_bg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let color = match self {
                         $(
@@ -41,6 +56,11 @@ macro_rules! colors {
                     };
 
                     write!(f, "{}", color)
+                }
+
+                #[cfg(feature = "no-color")]
+                fn fmt_ansi_bg(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    Ok(())
                 }
 
                 #[doc(hidden)]


### PR DESCRIPTION
I opened the PR to get some feedback before implementing the rest of the colors. I couldn't come up with something cleaner. I went with the approach that I mentioned in the issue and added blank implementations for the methods that print the control codes for the `no-color` feature.

For the `env-no-color` feature I added an additional check inside the formatting function that only writes the codes if the environment variable is set.

What do you think? Honestly, this doesn't feel that clean...

`colored` does it by adding a runtime check and returning an empty String in the case `NO_COLOR` is present:

https://github.com/mackwic/colored/blob/master/src/lib.rs#L374-L377