### PR TITLE
Add autoref specialization for compile-time colors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ tty = ["atty"]      # deprecated in favor of supports-colors
 
 [dependencies]
 atty = { version = "0.2", optional = true }
-supports-color = { version = "1.1", optional = true }
+supports-color = { version = "1.2", optional = true }

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -64,6 +64,9 @@ macro_rules! colors {
                 const ANSI_FG: &'static str = concat!("\x1b[", stringify!($fg), "m");
                 const ANSI_BG: &'static str = concat!("\x1b[", stringify!($bg), "m");
 
+                const RAW_ANSI_FG: &'static str = stringify!($fg);
+                const RAW_ANSI_BG: &'static str = stringify!($bg);
+
                 #[doc(hidden)]
                 fn into_dyncolors() -> crate::DynColors {
                     crate::DynColors::Ansi(ansi_colors::AnsiColors::$color)

--- a/src/colors/custom.rs
+++ b/src/colors/custom.rs
@@ -288,6 +288,35 @@ const fn rgb_to_ansi(r: u8, g: u8, b: u8, is_fg: bool) -> [u8; 19] {
     buf
 }
 
+const fn rgb_to_ansi_color(r: u8, g: u8, b: u8, is_fg: bool) -> [u8; 16] {
+    let mut buf = if is_fg {
+        *b"38;2;rrr;ggg;bbb"
+    } else {
+        *b"48;2;rrr;ggg;bbb"
+    };
+
+    let r = U8_TO_STR[r as usize];
+    let g = U8_TO_STR[g as usize];
+    let b = U8_TO_STR[b as usize];
+
+    // r 5
+    buf[5] = r[0];
+    buf[6] = r[1];
+    buf[7] = r[2];
+
+    // g 9
+    buf[9] = g[0];
+    buf[10] = g[1];
+    buf[11] = g[2];
+
+    // b 13
+    buf[13] = b[0];
+    buf[14] = b[1];
+    buf[15] = b[2];
+
+    buf
+}
+
 /// A custom RGB color, determined at compile time
 pub struct CustomColor<const R: u8, const G: u8, const B: u8>;
 
@@ -297,6 +326,11 @@ impl<const R: u8, const G: u8, const B: u8> Color for CustomColor<R, G, B> {
         unsafe { core::mem::transmute(&rgb_to_ansi(R, G, B, true) as &[u8]) };
     const ANSI_BG: &'static str =
         unsafe { core::mem::transmute(&rgb_to_ansi(R, G, B, false) as &[u8]) };
+
+    const RAW_ANSI_FG: &'static str =
+        unsafe { core::mem::transmute(&rgb_to_ansi_color(R, G, B, true) as &[u8]) };
+    const RAW_ANSI_BG: &'static str =
+        unsafe { core::mem::transmute(&rgb_to_ansi_color(R, G, B, false) as &[u8]) };
 
     fn into_dyncolors() -> crate::DynColors {
         crate::DynColors::Rgb(R, G, B)

--- a/src/colors/xterm.rs
+++ b/src/colors/xterm.rs
@@ -60,6 +60,9 @@ macro_rules! xterm_colors {
                 const ANSI_FG: &'static str = concat!("\x1b[38;5;", stringify!($xterm_num), "m");
                 const ANSI_BG: &'static str = concat!("\x1b[48;5;", stringify!($xterm_num), "m");
 
+                const RAW_ANSI_BG: &'static str = concat!("48;5;", stringify!($xterm_num));
+                const RAW_ANSI_FG: &'static str = concat!("48;5;", stringify!($xterm_num));
+
                 #[doc(hidden)]
                 fn into_dyncolors() -> crate::DynColors {
                     crate::DynColors::Xterm(dynamic::XtermColors::$name)

--- a/src/combo.rs
+++ b/src/combo.rs
@@ -1,0 +1,211 @@
+use crate::colors;
+use crate::{BgColorDisplay, Color, FgColorDisplay};
+
+use core::fmt;
+use core::marker::PhantomData;
+
+/// A wrapper type which applies both a foreground and background color
+pub struct ComboColorDisplay<'a, Fg: Color, Bg: Color, T>(&'a T, PhantomData<(Fg, Bg)>);
+
+macro_rules! impl_fmt_for_combo {
+    ($($trait:path),* $(,)?) => {
+        $(
+            impl<'a, Fg: Color, Bg: Color, T: $trait> $trait for ComboColorDisplay<'a, Fg, Bg, T> {
+                #[inline(always)]
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str("\x1b[")?;
+                    f.write_str(Fg::RAW_ANSI_FG)?;
+                    f.write_str(";")?;
+                    f.write_str(Bg::RAW_ANSI_BG)?;
+                    f.write_str("m")?;
+                    <T as $trait>::fmt(&self.0, f)?;
+                    f.write_str("\x1b[0m")
+                }
+            }
+        )*
+    };
+}
+
+impl_fmt_for_combo! {
+    fmt::Display,
+    fmt::Debug,
+    fmt::UpperHex,
+    fmt::LowerHex,
+    fmt::Binary,
+    fmt::UpperExp,
+    fmt::LowerExp,
+    fmt::Octal,
+    fmt::Pointer,
+}
+
+/// implement specialized color methods for FgColorDisplay BgColorDisplay, ComboColorDisplay
+macro_rules! color_methods {
+    ($(
+        #[$fg_meta:meta] #[$bg_meta:meta] $color:ident $fg_method:ident $bg_method:ident
+    ),* $(,)?) => {
+        const _: () = (); // workaround for syntax highlighting bug
+
+        impl<'a, Fg, T> FgColorDisplay<'a, Fg, T>
+        where
+            Fg: Color,
+        {
+            $(
+                #[$fg_meta]
+                #[inline(always)]
+                pub fn $fg_method(self) -> FgColorDisplay<'a, colors::$color, T> {
+                    FgColorDisplay(self.0, PhantomData)
+                }
+
+                #[$bg_meta]
+                #[inline(always)]
+                pub fn $bg_method(self) -> ComboColorDisplay<'a, Fg, colors::$color, T> {
+                    ComboColorDisplay(self.0, PhantomData)
+                }
+             )*
+        }
+
+        const _: () = (); // workaround for syntax highlighting bug
+
+        impl<'a, Bg, T> BgColorDisplay<'a, Bg, T>
+        where
+            Bg: Color,
+        {
+            $(
+                #[$bg_meta]
+                #[inline(always)]
+                pub fn $bg_method(self) -> BgColorDisplay<'a, colors::$color, T> {
+                    BgColorDisplay(self.0, PhantomData)
+                }
+
+                #[$fg_meta]
+                #[inline(always)]
+                pub fn $fg_method(self) -> ComboColorDisplay<'a, colors::$color, Bg, T> {
+                    ComboColorDisplay(self.0, PhantomData)
+                }
+             )*
+        }
+
+        const _: () = (); // workaround for syntax highlighting bug
+
+        impl<'a, Fg, Bg, T> ComboColorDisplay<'a, Fg, Bg, T>
+        where
+            Fg: Color,
+            Bg: Color,
+        {
+            $(
+                #[$bg_meta]
+                #[inline(always)]
+                pub fn $bg_method(self) -> ComboColorDisplay<'a, Fg, colors::$color, T> {
+                    ComboColorDisplay(self.0, PhantomData)
+                }
+
+                #[$fg_meta]
+                #[inline(always)]
+                pub fn $fg_method(self) -> ComboColorDisplay<'a, colors::$color, Bg, T> {
+                    ComboColorDisplay(self.0, PhantomData)
+                }
+             )*
+        }
+    };
+}
+
+const _: () = (); // workaround for syntax highlighting bug
+
+color_methods! {
+    /// Change the foreground color to black
+    /// Change the background color to black
+    Black    black    on_black,
+    /// Change the foreground color to red
+    /// Change the background color to red
+    Red      red      on_red,
+    /// Change the foreground color to green
+    /// Change the background color to green
+    Green    green    on_green,
+    /// Change the foreground color to yellow
+    /// Change the background color to yellow
+    Yellow   yellow   on_yellow,
+    /// Change the foreground color to blue
+    /// Change the background color to blue
+    Blue     blue     on_blue,
+    /// Change the foreground color to magenta
+    /// Change the background color to magenta
+    Magenta  magenta  on_magenta,
+    /// Change the foreground color to purple
+    /// Change the background color to purple
+    Magenta  purple   on_purple,
+    /// Change the foreground color to cyan
+    /// Change the background color to cyan
+    Cyan     cyan     on_cyan,
+    /// Change the foreground color to white
+    /// Change the background color to white
+    White    white    on_white,
+
+    /// Change the foreground color to bright black
+    /// Change the background color to bright black
+    BrightBlack    bright_black    on_bright_black,
+    /// Change the foreground color to bright red
+    /// Change the background color to bright red
+    BrightRed      bright_red      on_bright_red,
+    /// Change the foreground color to bright green
+    /// Change the background color to bright green
+    BrightGreen    bright_green    on_bright_green,
+    /// Change the foreground color to bright yellow
+    /// Change the background color to bright yellow
+    BrightYellow   bright_yellow   on_bright_yellow,
+    /// Change the foreground color to bright blue
+    /// Change the background color to bright blue
+    BrightBlue     bright_blue     on_bright_blue,
+    /// Change the foreground color to bright magenta
+    /// Change the background color to bright magenta
+    BrightMagenta  bright_magenta  on_bright_magenta,
+    /// Change the foreground color to bright purple
+    /// Change the background color to bright purple
+    BrightMagenta  bright_purple   on_bright_purple,
+    /// Change the foreground color to bright cyan
+    /// Change the background color to bright cyan
+    BrightCyan     bright_cyan     on_bright_cyan,
+    /// Change the foreground color to bright white
+    /// Change the background color to bright white
+    BrightWhite    bright_white    on_bright_white,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::OwoColorize;
+
+    #[test]
+    fn fg_bg_combo() {
+        let test = "test".red().on_blue();
+        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+    }
+
+    #[test]
+    fn bg_fg_combo() {
+        let test = "test".on_blue().red();
+        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+    }
+
+    #[test]
+    fn fg_overide() {
+        let test = "test".green().yellow().red().on_blue();
+        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+    }
+
+    #[test]
+    fn bg_overide() {
+        let test = "test".on_green().on_yellow().on_blue().red();
+        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+    }
+
+    #[test]
+    fn multiple_overide() {
+        let test = "test"
+            .on_green()
+            .on_yellow()
+            .on_red()
+            .green()
+            .on_blue()
+            .red();
+        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 #![warn(missing_docs)]
 
 pub mod colors;
+mod combo;
 mod dyn_colors;
 mod dyn_styles;
 pub mod styles;
@@ -69,6 +70,14 @@ pub trait Color {
 
     /// The ANSI format code for setting this color as the background
     const ANSI_BG: &'static str;
+
+    /// The raw ANSI format for settings this color as the foreground without the ANSI
+    /// delimiters ("\x1b" and "m")
+    const RAW_ANSI_FG: &'static str;
+
+    /// The raw ANSI format for settings this color as the background without the ANSI
+    /// delimiters ("\x1b" and "m")
+    const RAW_ANSI_BG: &'static str;
 
     #[doc(hidden)]
     fn into_dyncolors() -> crate::DynColors;
@@ -122,6 +131,8 @@ macro_rules! style_methods {
     };
 }
 
+const _: () = (); // workaround for syntax highlighting bug
+
 macro_rules! color_methods {
     ($(
         #[$fg_meta:meta] #[$bg_meta:meta] $color:ident $fg_method:ident $bg_method:ident
@@ -133,7 +144,7 @@ macro_rules! color_methods {
                 FgColorDisplay(self, PhantomData)
             }
 
-            #[$fg_meta]
+            #[$bg_meta]
             #[inline(always)]
             fn $bg_method<'a>(&'a self) -> BgColorDisplay<'a, colors::$color, Self> {
                 BgColorDisplay(self, PhantomData)
@@ -141,6 +152,8 @@ macro_rules! color_methods {
          )*
     };
 }
+
+const _: () = (); // workaround for syntax highlighting bug
 
 /// Extension trait for colorizing a type which implements any std formatter
 /// ([`Display`](core::fmt::Display), [`Debug`](core::fmt::Debug), [`UpperHex`](core::fmt::UpperHex),
@@ -468,7 +481,7 @@ pub use colors::{
 // TODO: figure out some wait to only implement for fmt::Display | fmt::Debug | ...
 impl<D: Sized> OwoColorize for D {}
 
-pub use {dyn_colors::*, dyn_styles::*};
+pub use {combo::ComboColorDisplay, dyn_colors::*, dyn_styles::*};
 
 #[cfg(feature = "tty")]
 mod tty_display;


### PR DESCRIPTION
This is the start of the work needed for #23. Runtime colors and non-color styling still needs this optimization