### PR TITLE
Add support for globally overriding if_supports_color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ all-features = true
 name = "supports_color"
 required-features = ["supports-colors"]
 
+[[example]]
+name = "override"
+required-features = ["supports-colors"]
+
 [features]
 supports-colors = ["supports-color"]
 

--- a/examples/override.rs
+++ b/examples/override.rs
@@ -1,0 +1,18 @@
+use owo_colors::{OwoColorize, Stream::Stdout};
+
+fn main() {
+    println!("Override color=always");
+    owo_colors::set_override(true);
+    println!("{}", "blue".if_supports_color(Stdout, |text| text.blue()));
+
+    println!("Override color=never");
+    owo_colors::set_override(false);
+    println!("{}", "green".if_supports_color(Stdout, |text| text.green()));
+
+    println!("Override color=auto");
+    owo_colors::unset_override();
+    println!(
+        "{}",
+        "yellow".if_supports_color(Stdout, |text| text.bright_yellow())
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,12 @@ pub use {combo::ComboColorDisplay, dyn_colors::*, dyn_styles::*};
 pub mod colored {
     pub use crate::AnsiColors as Color;
     pub use crate::OwoColorize;
+
+    /// A couple of functions to enable and disable coloring similarly to `colored`
+    #[cfg(feature = "supports-colors")]
+    pub mod control {
+        pub use crate::{set_override, unset_override};
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
 //! println!("{}", text.style(my_style));
 //! ```
 #![cfg_attr(not(test), no_std)]
+#![cfg_attr(doc, feature(doc_cfg))]
 #![doc(html_logo_url = "https://jam1.re/img/rust_owo.svg")]
 #![warn(missing_docs)]
 
@@ -77,6 +78,12 @@ mod combo;
 mod dyn_colors;
 mod dyn_styles;
 pub mod styles;
+
+#[cfg(feature = "supports-colors")]
+mod overrides;
+
+#[cfg(feature = "supports-colors")]
+pub(crate) use overrides::OVERRIDE;
 
 use core::fmt;
 use core::marker::PhantomData;
@@ -235,7 +242,7 @@ const _: () = (); // workaround for syntax highlighting bug
 /// **Do you want it to only display colors if it's a terminal?**
 ///
 /// 1. Enable the `supports-colors` feature
-/// 2. Colorize inside [`if_supports_color`](OwoColorize::if_supports_color)///
+/// 2. Colorize inside [`if_supports_color`](OwoColorize::if_supports_color)
 ///
 /// **Do you need to store a set of colors/effects to apply to multiple things?**
 ///
@@ -440,7 +447,11 @@ pub trait OwoColorize: Sized {
 mod supports_colors;
 
 #[cfg(feature = "supports-colors")]
-pub use {supports_color::Stream, supports_colors::SupportsColorsDisplay};
+pub use {
+    overrides::{set_override, unset_override},
+    supports_color::Stream,
+    supports_colors::SupportsColorsDisplay,
+};
 
 pub use colors::{
     ansi_colors::AnsiColors, css::dynamic::CssColors, dynamic::Rgb, xterm::dynamic::XtermColors,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //! println!("{}", text.style(my_style));
 //! ```
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(doc, feature(doc_cfg))]
+#![cfg_attr(all(doc, not(doctest)), feature(doc_cfg))]
 #![doc(html_logo_url = "https://jam1.re/img/rust_owo.svg")]
 #![warn(missing_docs)]
 

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -1,0 +1,59 @@
+use core::sync::atomic::{AtomicU8, Ordering};
+
+/// Set an override value for whether or not colors are supported.
+///
+/// If `true` is passed, [`if_supports_color`](crate::OwoColorize::if_supports_color) will always
+/// act as if colors are supported.
+///
+/// If `false` is passed, [`if_supports_color`](crate::OwoColorize::if_supports_color) will always
+/// act as if colors are **not** supported.
+///
+/// This behavior can be disabled using [`unset_override`], allowing `owo-colors` to return to
+/// inferring if colors are supported.
+#[cfg(feature = "supports-colors")]
+pub fn set_override(enabled: bool) {
+    OVERRIDE.set_force(enabled)
+}
+
+/// Remove any override value for whether or not colors are supported. This means
+/// [`if_supports_color`](crate::OwoColorize::if_supports_color) will resume checking if the given
+/// terminal output ([`Stream`](crate::Stream)) supports colors.
+///
+/// This override can be set using [`set_override`].
+#[cfg(feature = "supports-colors")]
+pub fn unset_override() {
+    OVERRIDE.unset()
+}
+
+pub(crate) static OVERRIDE: Override = Override::none();
+
+pub(crate) struct Override(AtomicU8);
+
+const FORCE_MASK: u8 = 0b10;
+const FORCE_ENABLE: u8 = 0b11;
+const FORCE_DISABLE: u8 = 0b10;
+const NO_FORCE: u8 = 0b00;
+
+impl Override {
+    const fn none() -> Self {
+        Self(AtomicU8::new(NO_FORCE))
+    }
+
+    fn inner(&self) -> u8 {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn is_force_enabled_or_disabled(&self) -> (bool, bool) {
+        let inner = self.inner();
+
+        (inner == FORCE_ENABLE, inner == FORCE_DISABLE)
+    }
+
+    fn set_force(&self, enable: bool) {
+        self.0.store(FORCE_MASK | (enable as u8), Ordering::SeqCst)
+    }
+
+    fn unset(&self) {
+        self.0.store(0, Ordering::SeqCst);
+    }
+}


### PR DESCRIPTION
Closes #33.

Override example included:

```rust
use owo_colors::{OwoColorize, Stream::Stdout};

fn main() {
    println!("Override color=always");
    owo_colors::set_override(true);
    println!("{}", "blue".if_supports_color(Stdout, |text| text.blue()));

    println!("Override color=never");
    owo_colors::set_override(false);
    println!("{}", "green".if_supports_color(Stdout, |text| text.green()));

    println!("Override color=auto");
    owo_colors::unset_override();
    println!(
        "{}",
        "yellow".if_supports_color(Stdout, |text| text.bright_yellow())
    );
}
```