### PR TITLE
only enable doc_cfg when a cfg attribute is passed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-interface"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]
 
 [[example]]
 name = "supports_color"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //! println!("{}", text.style(my_style));
 //! ```
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(all(doc, not(doctest)), feature(doc_cfg))]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![doc(html_logo_url = "https://jam1.re/img/rust_owo.svg")]
 #![warn(missing_docs)]
 


### PR DESCRIPTION
Also turn it on for docs.rs.

Fixes #38.