### PR TITLE
Expose `StyedList` contents

### DIFF
--- a/src/styled_list.rs
+++ b/src/styled_list.rs
@@ -61,7 +61,7 @@ impl<T: Display> IsStyled for Styled<T> {
 ///
 /// assert!(styled_length < normal_length);
 /// ```
-pub struct StyledList<T, U>(T, PhantomData<fn(U)>)
+pub struct StyledList<T, U>(pub T, PhantomData<fn(U)>)
 where
     T: AsRef<[U]>,
     U: IsStyled;


### PR DESCRIPTION
This still won't allow direct construction because of the `PhnatomData` member.