### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ terminal to make people go owo.
   - [x] Enabled for CI
   - [x] Disabled by default for non-terminal outputs
   - [x] Overridable by `NO_COLOR`/`FORCE_COLOR` environment variables
-  - [x] Overridable programatically via [`set_override`](https://docs.rs/owo-colors/latest/owo_colors/fn.set_override.html)
+  - [x] Overridable programmatically via [`set_override`](https://docs.rs/owo-colors/latest/owo_colors/fn.set_override.html)
 - [x] Dependency-less by default
 - [x] Hand picked names for all ANSI (4-bit) and Xterm (8-bit) colors
 - [x] Support for RGB colors

--- a/src/dyn_styles.rs
+++ b/src/dyn_styles.rs
@@ -65,7 +65,7 @@ pub struct Styled<T> {
 }
 
 /// A pre-computed style that can be applied to a struct using [`OwoColorize::style`]. Its
-/// interface mimicks that of [`OwoColorize`], but instead of chaining methods on your
+/// interface mimics that of [`OwoColorize`], but instead of chaining methods on your
 /// object, you instead chain them on the `Style` object before applying it.
 ///
 /// ```rust

--- a/src/styled_list.rs
+++ b/src/styled_list.rs
@@ -111,7 +111,7 @@ where
 }
 
 impl<'a> Style {
-    /// Retuns an enum that indicates how the transition from one style to this style should be printed
+    /// Returns an enum that indicates how the transition from one style to this style should be printed
     fn transition_from(&'a self, from: &Style) -> Transition<'a> {
         if self == from {
             return Transition::Noop;


### PR DESCRIPTION
Found via `codespell -L crate .`