### PR TITLE
overwrite color support temporarily during function execution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,7 +467,7 @@ mod supports_colors;
 
 #[cfg(feature = "supports-colors")]
 pub use {
-    overrides::{set_override, unset_override},
+    overrides::{set_override, unset_override, with_override},
     supports_color::Stream,
     supports_colors::SupportsColorsDisplay,
 };

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -1,5 +1,29 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
+/// Set an override value for whether or not colors are supported using
+/// [`set_override`] while executing the closure provided.
+///
+/// Once the function has executed the value will be reset to the previous set
+/// (or unset) override.
+///
+/// This is especially useful in use-cases where one would like to temporarily
+/// override the supported color set, without impacting previous configurations.
+///
+/// ```
+/// # use supports_color::Stream;
+/// # use owo_colors::{OwoColorize, set_override, unset_override, with_override};
+/// # use owo_colors::colors::Black;
+/// #
+/// set_override(false);
+/// assert_eq!("example".if_supports_color(Stream::Stdout, |value| value.bg::<Black>()).to_string(), "example");
+///
+/// with_override(true, || {
+///     assert_eq!("example".if_supports_color(Stream::Stdout, |value| value.bg::<Black>()).to_string(), "\x1b[40mexample\x1b[49m");
+/// });
+///
+/// assert_eq!("example".if_supports_color(Stream::Stdout, |value| value.bg::<Black>()).to_string(), "example");
+/// # unset_override() // make sure that other doc tests are not impacted
+/// ```
 #[cfg(feature = "supports-colors")]
 pub fn with_override<T, F: FnOnce() -> T>(enabled: bool, f: F) -> T {
     let previous = OVERRIDE.inner();
@@ -14,22 +38,25 @@ pub fn with_override<T, F: FnOnce() -> T>(enabled: bool, f: F) -> T {
 
 /// Set an override value for whether or not colors are supported.
 ///
-/// If `true` is passed, [`if_supports_color`](crate::OwoColorize::if_supports_color) will always
-/// act as if colors are supported.
+/// If `true` is passed,
+/// [`if_supports_color`](crate::OwoColorize::if_supports_color) will always act
+/// as if colors are supported.
 ///
-/// If `false` is passed, [`if_supports_color`](crate::OwoColorize::if_supports_color) will always
-/// act as if colors are **not** supported.
+/// If `false` is passed,
+/// [`if_supports_color`](crate::OwoColorize::if_supports_color) will always act
+/// as if colors are **not** supported.
 ///
-/// This behavior can be disabled using [`unset_override`], allowing `owo-colors` to return to
-/// inferring if colors are supported.
+/// This behavior can be disabled using [`unset_override`], allowing
+/// `owo-colors` to return to inferring if colors are supported.
 #[cfg(feature = "supports-colors")]
 pub fn set_override(enabled: bool) {
     OVERRIDE.set_force(enabled);
 }
 
-/// Remove any override value for whether or not colors are supported. This means
-/// [`if_supports_color`](crate::OwoColorize::if_supports_color) will resume checking if the given
-/// terminal output ([`Stream`](crate::Stream)) supports colors.
+/// Remove any override value for whether or not colors are supported. This
+/// means [`if_supports_color`](crate::OwoColorize::if_supports_color) will
+/// resume checking if the given terminal output ([`Stream`](crate::Stream))
+/// supports colors.
 ///
 /// This override can be set using [`set_override`].
 #[cfg(feature = "supports-colors")]


### PR DESCRIPTION
This is relatively straightforward without creating an issue first. Still, I hope that is okay, as I did not want to duplicate the information provided in both the issue and PR for such a minor issue/feature. Please be free to close this PR if this isn't something that you want this crate to provide or think is inappropriate!

---

During the development of [error-stack](https://lib.rs/crates/error-stack) 0.3, I wanted to temporarily disable the colored output without impacting the previous set configuration. This is currently impossible because one cannot check the current overwrite value. Instead of increasing the API surface by introducing a new function that checks the current overwrite, instead, a new function is added: `with_override`, which complements `set_override` and `unset_override`. This function will save the current configuration, set the configuration accordingly and then reset to the previous value.