### PR TITLE
feature separation of `supports-colors`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,11 @@ name = "override"
 required-features = ["supports-colors"]
 
 [features]
-supports-colors = ["supports-color"]
+default = ["std"]
+std = []
 alloc = []
+overwrite = []
+supports-colors = ["overwrite", "std", "supports-color"]
 
 [dependencies]
 supports-color = { version = "2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ required-features = ["supports-colors"]
 
 [[example]]
 name = "override"
-required-features = ["supports-colors"]
+required-features = ["override"]
 
 [features]
 default = ["std"]
 std = []
 alloc = []
-overwrite = []
-supports-colors = ["overwrite", "std", "supports-color"]
+override = []
+supports-colors = ["override", "std", "supports-color"]
 
 [dependencies]
 supports-color = { version = "2.0", optional = true }

--- a/src/combo.rs
+++ b/src/combo.rs
@@ -1,18 +1,18 @@
-use crate::{colors, BgDynColorDisplay, DynColor, FgDynColorDisplay};
-use crate::{BgColorDisplay, Color, FgColorDisplay};
-
 use core::fmt;
 use core::marker::PhantomData;
 
 #[cfg(doc)]
 use crate::OwoColorize;
+use crate::{
+    colors, BgColorDisplay, BgDynColorDisplay, Color, DynColor, FgColorDisplay, FgDynColorDisplay,
+};
 
 /// A wrapper type which applies both a foreground and background color
 pub struct ComboColorDisplay<'a, Fg: Color, Bg: Color, T>(&'a T, PhantomData<(Fg, Bg)>);
 
-/// Wrapper around a type which implements all the formatters the wrapped type does,
-/// with the addition of changing the foreground and background color. Is not recommended
-/// unless compile-time coloring is not an option.
+/// Wrapper around a type which implements all the formatters the wrapped type
+/// does, with the addition of changing the foreground and background color. Is
+/// not recommended unless compile-time coloring is not an option.
 pub struct ComboDynColorDisplay<'a, Fg: DynColor, Bg: DynColor, T>(&'a T, Fg, Bg);
 
 macro_rules! impl_fmt_for_combo {
@@ -61,7 +61,8 @@ impl_fmt_for_combo! {
     fmt::Pointer,
 }
 
-/// implement specialized color methods for FgColorDisplay BgColorDisplay, ComboColorDisplay
+/// implement specialized color methods for FgColorDisplay BgColorDisplay,
+/// ComboColorDisplay
 macro_rules! color_methods {
     ($(
         #[$fg_meta:meta] #[$bg_meta:meta] $color:ident $fg_method:ident $bg_method:ident
@@ -355,9 +356,10 @@ color_methods! {
 }
 
 impl<'a, Fg: DynColor, T> FgDynColorDisplay<'a, Fg, T> {
-    /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// Set the background color at runtime. Only use if you do not know what
+    /// color to use at compile-time. If the color is constant, use either
+    /// [`OwoColorize::bg`](OwoColorize::bg) or a color-specific method,
+    /// such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -369,9 +371,10 @@ impl<'a, Fg: DynColor, T> FgDynColorDisplay<'a, Fg, T> {
         ComboDynColorDisplay(inner, fg, bg)
     }
 
-    /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// Set the foreground color at runtime. Only use if you do not know which
+    /// color will be used at compile-time. If the color is constant, use
+    /// either [`OwoColorize::fg`](OwoColorize::fg) or a color-specific
+    /// method, such as [`OwoColorize::green`](OwoColorize::green),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -385,9 +388,10 @@ impl<'a, Fg: DynColor, T> FgDynColorDisplay<'a, Fg, T> {
 }
 
 impl<'a, Bg: DynColor, T> BgDynColorDisplay<'a, Bg, T> {
-    /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// Set the background color at runtime. Only use if you do not know what
+    /// color to use at compile-time. If the color is constant, use either
+    /// [`OwoColorize::bg`](OwoColorize::bg) or a color-specific method,
+    /// such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -399,9 +403,10 @@ impl<'a, Bg: DynColor, T> BgDynColorDisplay<'a, Bg, T> {
         BgDynColorDisplay(inner, bg)
     }
 
-    /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// Set the foreground color at runtime. Only use if you do not know which
+    /// color will be used at compile-time. If the color is constant, use
+    /// either [`OwoColorize::fg`](OwoColorize::fg) or a color-specific
+    /// method, such as [`OwoColorize::green`](OwoColorize::green),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -415,9 +420,10 @@ impl<'a, Bg: DynColor, T> BgDynColorDisplay<'a, Bg, T> {
 }
 
 impl<'a, Fg: DynColor, Bg: DynColor, T> ComboDynColorDisplay<'a, Fg, Bg, T> {
-    /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// Set the background color at runtime. Only use if you do not know what
+    /// color to use at compile-time. If the color is constant, use either
+    /// [`OwoColorize::bg`](OwoColorize::bg) or a color-specific method,
+    /// such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -429,9 +435,10 @@ impl<'a, Fg: DynColor, Bg: DynColor, T> ComboDynColorDisplay<'a, Fg, Bg, T> {
         ComboDynColorDisplay(inner, fg, bg)
     }
 
-    /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// Set the foreground color at runtime. Only use if you do not know which
+    /// color will be used at compile-time. If the color is constant, use
+    /// either [`OwoColorize::fg`](OwoColorize::fg) or a color-specific
+    /// method, such as [`OwoColorize::green`](OwoColorize::green),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -446,42 +453,44 @@ impl<'a, Fg: DynColor, Bg: DynColor, T> ComboDynColorDisplay<'a, Fg, Bg, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{colors::*, AnsiColors, OwoColorize};
+    use crate::colors::*;
+    use crate::tests::assert_str;
+    use crate::{AnsiColors, OwoColorize};
 
     #[test]
     fn fg_bg_combo() {
         let test = "test".red().on_blue();
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
     fn bg_fg_combo() {
         let test = "test".on_blue().red();
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
     fn fg_bg_dyn_combo() {
         let test = "test".color(AnsiColors::Red).on_color(AnsiColors::Blue);
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
     fn bg_fg_dyn_combo() {
         let test = "test".on_color(AnsiColors::Blue).color(AnsiColors::Red);
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
     fn fg_overide() {
         let test = "test".green().yellow().red().on_blue();
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
     fn bg_overide() {
         let test = "test".on_green().on_yellow().on_blue().red();
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
@@ -493,7 +502,7 @@ mod tests {
             .green()
             .on_blue()
             .red();
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
 
         let test = "test"
             .color(AnsiColors::Blue)
@@ -501,7 +510,7 @@ mod tests {
             .on_color(AnsiColors::Black)
             .color(AnsiColors::Red)
             .on_color(AnsiColors::Blue);
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
 
         let test = "test"
             .on_yellow()
@@ -509,7 +518,7 @@ mod tests {
             .on_color(AnsiColors::Black)
             .color(AnsiColors::Red)
             .on_color(AnsiColors::Blue);
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
 
         let test = "test"
             .yellow()
@@ -517,7 +526,7 @@ mod tests {
             .color(AnsiColors::Red)
             .on_color(AnsiColors::Black)
             .on_color(AnsiColors::Blue);
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
 
         let test = "test"
             .yellow()
@@ -525,7 +534,7 @@ mod tests {
             .on_color(AnsiColors::Black)
             .color(AnsiColors::Red)
             .on_color(AnsiColors::Blue);
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
@@ -539,18 +548,18 @@ mod tests {
             .fg::<Green>()
             .bg::<Blue>()
             .fg::<Red>();
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
     fn fg_bg_combo_generic() {
         let test = "test".fg::<Red>().bg::<Blue>();
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
     fn bg_fg_combo_generic() {
         let test = "test".bg::<Blue>().fg::<Red>();
-        assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
+        assert_str(test, "\x1b[31;44mtest\x1b[0m");
     }
 }

--- a/src/dyn_styles.rs
+++ b/src/dyn_styles.rs
@@ -1,8 +1,8 @@
-use crate::{AnsiColors, Color, DynColor, DynColors};
 use core::fmt;
 
 #[cfg(doc)]
 use crate::OwoColorize;
+use crate::{AnsiColors, Color, DynColor, DynColors};
 
 /// A runtime-configurable text effect for use with [`Style`]
 #[allow(missing_docs)]
@@ -64,9 +64,10 @@ pub struct Styled<T> {
     pub style: Style,
 }
 
-/// A pre-computed style that can be applied to a struct using [`OwoColorize::style`]. Its
-/// interface mimics that of [`OwoColorize`], but instead of chaining methods on your
-/// object, you instead chain them on the `Style` object before applying it.
+/// A pre-computed style that can be applied to a struct using
+/// [`OwoColorize::style`]. Its interface mimics that of [`OwoColorize`], but
+/// instead of chaining methods on your object, you instead chain them on the
+/// `Style` object before applying it.
 ///
 /// ```rust
 /// use owo_colors::{OwoColorize, Style};
@@ -127,68 +128,6 @@ impl StyleFlags {
 }
 
 impl Style {
-    /// Create a new style to be applied later
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Apply the style to a given struct to output
-    pub fn style<T>(&self, target: T) -> Styled<T> {
-        Styled {
-            target,
-            style: *self,
-        }
-    }
-
-    /// Set the foreground color generically
-    ///
-    /// ```rust
-    /// use owo_colors::{OwoColorize, colors::*};
-    ///
-    /// println!("{}", "red foreground".fg::<Red>());
-    /// ```
-    #[must_use]
-    pub fn fg<C: Color>(mut self) -> Self {
-        self.fg = Some(C::into_dyncolors());
-        self
-    }
-
-    /// Set the background color generically.
-    ///
-    /// ```rust
-    /// use owo_colors::{OwoColorize, colors::*};
-    ///
-    /// println!("{}", "black background".bg::<Black>());
-    /// ```
-    #[must_use]
-    pub fn bg<C: Color>(mut self) -> Self {
-        self.bg = Some(C::into_dyncolors());
-        self
-    }
-
-    /// Removes the foreground color from the style. Note that this does not apply
-    /// the default color, but rather represents not changing the current terminal color.
-    ///
-    /// If you wish to actively change the terminal color back to the default, see
-    /// [`Style::default_color`].
-    #[must_use]
-    pub fn remove_fg(mut self) -> Self {
-        self.fg = None;
-        self
-    }
-
-    /// Removes the background color from the style. Note that this does not apply
-    /// the default color, but rather represents not changing the current terminal color.
-    ///
-    /// If you wish to actively change the terminal color back to the default, see
-    /// [`Style::on_default_color`].
-    #[must_use]
-    pub fn remove_bg(mut self) -> Self {
-        self.bg = None;
-        self
-    }
-
     color_methods! {
         /// Change the foreground color to black
         /// Change the background color to black
@@ -251,13 +190,6 @@ impl Style {
         BrightWhite    bright_white    on_bright_white,
     }
 
-    /// Make the text bold
-    #[must_use]
-    pub fn bold(mut self) -> Self {
-        self.bold = true;
-        self
-    }
-
     style_methods! {
         /// Make the text dim
         (dimmed, set_dimmed),
@@ -275,6 +207,77 @@ impl Style {
         (hidden, set_hidden),
         /// Cross out the text
         (strikethrough, set_strikethrough),
+    }
+
+    /// Create a new style to be applied later
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply the style to a given struct to output
+    pub fn style<T>(&self, target: T) -> Styled<T> {
+        Styled {
+            target,
+            style: *self,
+        }
+    }
+
+    /// Set the foreground color generically
+    ///
+    /// ```rust
+    /// use owo_colors::{OwoColorize, colors::*};
+    ///
+    /// println!("{}", "red foreground".fg::<Red>());
+    /// ```
+    #[must_use]
+    pub fn fg<C: Color>(mut self) -> Self {
+        self.fg = Some(C::into_dyncolors());
+        self
+    }
+
+    /// Set the background color generically.
+    ///
+    /// ```rust
+    /// use owo_colors::{OwoColorize, colors::*};
+    ///
+    /// println!("{}", "black background".bg::<Black>());
+    /// ```
+    #[must_use]
+    pub fn bg<C: Color>(mut self) -> Self {
+        self.bg = Some(C::into_dyncolors());
+        self
+    }
+
+    /// Removes the foreground color from the style. Note that this does not
+    /// apply the default color, but rather represents not changing the
+    /// current terminal color.
+    ///
+    /// If you wish to actively change the terminal color back to the default,
+    /// see [`Style::default_color`].
+    #[must_use]
+    pub fn remove_fg(mut self) -> Self {
+        self.fg = None;
+        self
+    }
+
+    /// Removes the background color from the style. Note that this does not
+    /// apply the default color, but rather represents not changing the
+    /// current terminal color.
+    ///
+    /// If you wish to actively change the terminal color back to the default,
+    /// see [`Style::on_default_color`].
+    #[must_use]
+    pub fn remove_bg(mut self) -> Self {
+        self.bg = None;
+        self
+    }
+
+    /// Make the text bold
+    #[must_use]
+    pub fn bold(mut self) -> Self {
+        self.bold = true;
+        self
     }
 
     fn set_effect(&mut self, effect: Effect, to: bool) {
@@ -334,9 +337,11 @@ impl Style {
         self
     }
 
-    /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](crate::OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](crate::OwoColorize::green),
+    /// Set the foreground color at runtime. Only use if you do not know which
+    /// color will be used at compile-time. If the color is constant, use
+    /// either [`OwoColorize::fg`](crate::OwoColorize::fg) or
+    /// a color-specific method, such as
+    /// [`OwoColorize::green`](crate::OwoColorize::green),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -349,9 +354,11 @@ impl Style {
         self
     }
 
-    /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](crate::OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](crate::OwoColorize::on_yellow),
+    /// Set the background color at runtime. Only use if you do not know what
+    /// color to use at compile-time. If the color is constant, use either
+    /// [`OwoColorize::bg`](crate::OwoColorize::bg) or a color-specific
+    /// method, such as
+    /// [`OwoColorize::on_yellow`](crate::OwoColorize::on_yellow),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -533,6 +540,7 @@ impl_fmt! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::assert_str;
     use crate::{AnsiColors, OwoColorize};
 
     struct StylePrefixOnly(Style);
@@ -564,15 +572,13 @@ mod tests {
             //.hidden()
             .strikethrough();
         let s = style.style("TEST");
-        let s2 = format!("{}", &s);
-        println!("{}", &s2);
-        assert_eq!(&s2, "\u{1b}[97;44;1;2;3;4;5;9mTEST\u{1b}[0m");
+        assert_str(s, "\u{1b}[97;44;1;2;3;4;5;9mTEST\u{1b}[0m");
 
-        let prefix = format!("{}", StylePrefixOnly(style));
-        assert_eq!(&prefix, "\u{1b}[97;44;1;2;3;4;5;9m");
+        let prefix = StylePrefixOnly(style);
+        assert_str(prefix, "\u{1b}[97;44;1;2;3;4;5;9m");
 
-        let suffix = format!("{}", StyleSuffixOnly(style));
-        assert_eq!(&suffix, "\u{1b}[0m");
+        let suffix = StyleSuffixOnly(style);
+        assert_str(suffix, "\u{1b}[0m");
     }
 
     #[test]
@@ -581,9 +587,7 @@ mod tests {
         let style = Style::new().effects(&[Strikethrough, Underline]);
 
         let s = style.style("TEST");
-        let s2 = format!("{}", &s);
-        println!("{}", &s2);
-        assert_eq!(&s2, "\u{1b}[4;9mTEST\u{1b}[0m");
+        assert_str(s, "\u{1b}[4;9mTEST\u{1b}[0m");
     }
 
     #[test]
@@ -593,9 +597,7 @@ mod tests {
             .on_color(AnsiColors::Black);
 
         let s = style.style("TEST");
-        let s2 = format!("{}", &s);
-        println!("{}", &s2);
-        assert_eq!(&s2, "\u{1b}[37;40mTEST\u{1b}[0m");
+        assert_str(s, "\u{1b}[37;40mTEST\u{1b}[0m");
     }
 
     #[test]
@@ -603,20 +605,16 @@ mod tests {
         let style = Style::new().truecolor(255, 255, 255).on_truecolor(0, 0, 0);
 
         let s = style.style("TEST");
-        let s2 = format!("{}", &s);
-        println!("{}", &s2);
-        assert_eq!(&s2, "\u{1b}[38;2;255;255;255;48;2;0;0;0mTEST\u{1b}[0m");
+        assert_str(s, "\u{1b}[38;2;255;255;255;48;2;0;0;0mTEST\u{1b}[0m");
     }
 
     #[test]
     fn test_string_reference() {
         let style = Style::new().truecolor(255, 255, 255).on_truecolor(0, 0, 0);
 
-        let string = String::from("TEST");
-        let s = style.style(&string);
-        let s2 = format!("{}", &s);
-        println!("{}", &s2);
-        assert_eq!(&s2, "\u{1b}[38;2;255;255;255;48;2;0;0;0mTEST\u{1b}[0m");
+        let string = "TEST";
+        let s = style.style(string);
+        assert_str(s, "\u{1b}[38;2;255;255;255;48;2;0;0;0mTEST\u{1b}[0m");
     }
 
     #[test]
@@ -624,9 +622,7 @@ mod tests {
         let style = Style::new().bright_white().on_blue();
 
         let s = "TEST".style(style);
-        let s2 = format!("{}", &s);
-        println!("{}", &s2);
-        assert_eq!(&s2, "\u{1b}[97;44mTEST\u{1b}[0m");
+        assert_str(s, "\u{1b}[97;44mTEST\u{1b}[0m");
     }
 
     #[test]
@@ -636,11 +632,10 @@ mod tests {
         assert!(!style.is_plain());
         assert!(Style::default().is_plain());
 
-        let string = String::from("TEST");
-        let s = Style::default().style(&string);
-        let s2 = format!("{}", &s);
+        let target = "TEST";
+        let s = Style::default().style(target);
 
-        assert_eq!(string, s2)
+        assert_str(s, target)
     }
 
     #[test]
@@ -653,6 +648,6 @@ mod tests {
 
         *s.inner_mut() = &"changed";
         assert_eq!(&&"changed", s.inner());
-        assert_eq!("changed", format!("{}", s));
+        assert_str(s, "changed");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,8 @@
 #![doc(html_logo_url = "https://jam1.re/img/rust_owo.svg")]
 #![warn(missing_docs)]
 
+extern crate core;
+
 pub mod colors;
 mod combo;
 mod dyn_colors;
@@ -484,7 +486,7 @@ pub use colors::dynamic::Rgb;
 pub use colors::xterm::dynamic::XtermColors;
 #[cfg(feature = "override")]
 pub use overrides::{set_override, unset_override, with_override, Stream};
-#[cfg(feature = "supports-colors")]
+#[cfg(feature = "override")]
 pub use supports_colors::SupportsColorsDisplay;
 
 // TODO: figure out some wait to only implement for fmt::Display | fmt::Debug |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 //!
 //! ---
 //!
-//! This crate provides [`OwoColorize`](OwoColorize), an extension trait for colorizing a
-//! given type.
+//! This crate provides [`OwoColorize`](OwoColorize), an extension trait for
+//! colorizing a given type.
 //!
 //! ## Example
 //!
@@ -53,14 +53,15 @@
 //! # }
 //! ```
 //!
-//! Supports `NO_COLOR`/`FORCE_COLOR` environment variables, checks if it's a tty, checks
-//! if it's running in CI (and thus likely supports color), and checks which terminal is being
-//! used. (Note: requires `supports-colors` feature)
+//! Supports `NO_COLOR`/`FORCE_COLOR` environment variables, checks if it's a
+//! tty, checks if it's running in CI (and thus likely supports color), and
+//! checks which terminal is being used. (Note: requires `supports-colors`
+//! feature)
 //!
 //! ## Style Objects
 //!
-//! owo-colors also features the ability to create a [`Style`] object and use it to
-//! apply the same set of colors/effects to any number of things to display.
+//! owo-colors also features the ability to create a [`Style`] object and use it
+//! to apply the same set of colors/effects to any number of things to display.
 //!
 //! ```rust
 //! use owo_colors::{OwoColorize, Style};
@@ -73,7 +74,7 @@
 //! let text = "red text, white background, struck through";
 //! println!("{}", text.style(my_style));
 //! ```
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![doc(html_logo_url = "https://jam1.re/img/rust_owo.svg")]
 #![warn(missing_docs)]
@@ -85,17 +86,17 @@ mod dyn_styles;
 mod styled_list;
 pub mod styles;
 
-#[cfg(feature = "supports-colors")]
+#[cfg(feature = "override")]
 mod overrides;
-
-#[cfg(feature = "supports-colors")]
-pub(crate) use overrides::OVERRIDE;
 
 use core::fmt;
 use core::marker::PhantomData;
 
-/// A trait for describing a type which can be used with [`FgColorDisplay`](FgColorDisplay) or
-/// [`BgCBgColorDisplay`](BgColorDisplay)
+#[cfg(feature = "override")]
+pub(crate) use overrides::OVERRIDE;
+
+/// A trait for describing a type which can be used with
+/// [`FgColorDisplay`](FgColorDisplay) or [`BgCBgColorDisplay`](BgColorDisplay)
 pub trait Color {
     /// The ANSI format code for setting this color as the foreground
     const ANSI_FG: &'static str;
@@ -103,12 +104,12 @@ pub trait Color {
     /// The ANSI format code for setting this color as the background
     const ANSI_BG: &'static str;
 
-    /// The raw ANSI format for settings this color as the foreground without the ANSI
-    /// delimiters ("\x1b" and "m")
+    /// The raw ANSI format for settings this color as the foreground without
+    /// the ANSI delimiters ("\x1b" and "m")
     const RAW_ANSI_FG: &'static str;
 
-    /// The raw ANSI format for settings this color as the background without the ANSI
-    /// delimiters ("\x1b" and "m")
+    /// The raw ANSI format for settings this color as the background without
+    /// the ANSI delimiters ("\x1b" and "m")
     const RAW_ANSI_BG: &'static str;
 
     #[doc(hidden)]
@@ -121,21 +122,24 @@ pub trait Color {
     fn into_dyncolors() -> crate::DynColors;
 }
 
-/// A trait describing a runtime-configurable color which can displayed using [`FgDynColorDisplay`](FgDynColorDisplay)
-/// or [`BgDynColorDisplay`](BgDynColorDisplay). If your color will be known at compile time it
-/// is recommended you avoid this.
+/// A trait describing a runtime-configurable color which can displayed using
+/// [`FgDynColorDisplay`](FgDynColorDisplay)
+/// or [`BgDynColorDisplay`](BgDynColorDisplay). If your color will be known at
+/// compile time it is recommended you avoid this.
 pub trait DynColor {
-    /// A function to output a ANSI code to a formatter to set the foreground to this color
+    /// A function to output a ANSI code to a formatter to set the foreground to
+    /// this color
     fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
-    /// A function to output a ANSI code to a formatter to set the background to this color
+    /// A function to output a ANSI code to a formatter to set the background to
+    /// this color
     fn fmt_ansi_bg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
-    /// A function to output a raw ANSI code to a formatter to set the foreground to this color,
-    /// but without including the ANSI delimiters.
+    /// A function to output a raw ANSI code to a formatter to set the
+    /// foreground to this color, but without including the ANSI delimiters.
     fn fmt_raw_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
-    /// A function to output a raw ANSI code to a formatter to set the background to this color,
-    /// but without including the ANSI delimiters.
+    /// A function to output a raw ANSI code to a formatter to set the
+    /// background to this color, but without including the ANSI delimiters.
     fn fmt_raw_ansi_bg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
     #[doc(hidden)]
@@ -144,26 +148,26 @@ pub trait DynColor {
     fn get_dyncolors_bg(&self) -> DynColors;
 }
 
-/// Transparent wrapper around a type which implements all the formatters the wrapped type does,
-/// with the addition of changing the foreground color. Recommended to be constructed using
-/// [`OwoColorize`](OwoColorize).
+/// Transparent wrapper around a type which implements all the formatters the
+/// wrapped type does, with the addition of changing the foreground color.
+/// Recommended to be constructed using [`OwoColorize`](OwoColorize).
 #[repr(transparent)]
 pub struct FgColorDisplay<'a, C: Color, T>(&'a T, PhantomData<C>);
 
-/// Transparent wrapper around a type which implements all the formatters the wrapped type does,
-/// with the addition of changing the background color. Recommended to be constructed using
-/// [`OwoColorize`](OwoColorize).
+/// Transparent wrapper around a type which implements all the formatters the
+/// wrapped type does, with the addition of changing the background color.
+/// Recommended to be constructed using [`OwoColorize`](OwoColorize).
 #[repr(transparent)]
 pub struct BgColorDisplay<'a, C: Color, T>(&'a T, PhantomData<C>);
 
-/// Wrapper around a type which implements all the formatters the wrapped type does,
-/// with the addition of changing the foreground color. Is not recommended unless compile-time
-/// coloring is not an option.
+/// Wrapper around a type which implements all the formatters the wrapped type
+/// does, with the addition of changing the foreground color. Is not recommended
+/// unless compile-time coloring is not an option.
 pub struct FgDynColorDisplay<'a, Color: DynColor, T>(&'a T, Color);
 
-/// Wrapper around a type which implements all the formatters the wrapped type does,
-/// with the addition of changing the background color. Is not recommended unless compile-time
-/// coloring is not an option.
+/// Wrapper around a type which implements all the formatters the wrapped type
+/// does, with the addition of changing the background color. Is not recommended
+/// unless compile-time coloring is not an option.
 pub struct BgDynColorDisplay<'a, Color: DynColor, T>(&'a T, Color);
 
 macro_rules! style_methods {
@@ -206,8 +210,8 @@ macro_rules! color_methods {
 const _: () = (); // workaround for syntax highlighting bug
 
 /// Extension trait for colorizing a type which implements any std formatter
-/// ([`Display`](core::fmt::Display), [`Debug`](core::fmt::Debug), [`UpperHex`](core::fmt::UpperHex),
-/// etc.)
+/// ([`Display`](core::fmt::Display), [`Debug`](core::fmt::Debug),
+/// [`UpperHex`](core::fmt::UpperHex), etc.)
 ///
 /// ## Example
 ///
@@ -228,13 +232,15 @@ const _: () = (); // workaround for syntax highlighting bug
 ///
 /// **Do you want your colors configurable via generics?**
 ///
-/// Use [`fg`](OwoColorize::fg) and [`bg`](OwoColorize::bg) to make it compile-time configurable.
+/// Use [`fg`](OwoColorize::fg) and [`bg`](OwoColorize::bg) to make it
+/// compile-time configurable.
 ///
 ///
 /// **Do you need to pick a color at runtime?**
 ///
 /// Use the [`color`](OwoColorize::color), [`on_color`](OwoColorize::on_color),
-/// [`truecolor`](OwoColorize::truecolor) or [`on_truecolor`](OwoColorize::on_truecolor).
+/// [`truecolor`](OwoColorize::truecolor) or
+/// [`on_truecolor`](OwoColorize::on_truecolor).
 ///
 /// **Do you need some other text modifier?**
 ///
@@ -250,13 +256,13 @@ const _: () = (); // workaround for syntax highlighting bug
 ///
 /// **Do you want it to only display colors if it's a terminal?**
 ///
-/// 1. Enable the `supports-colors` feature
+/// 1. Enable the `supports-colors`, or `override` feature
 /// 2. Colorize inside [`if_supports_color`](OwoColorize::if_supports_color)
 ///
-/// **Do you need to store a set of colors/effects to apply to multiple things?**
+/// **Do you need to store a set of colors/effects to apply to multiple
+/// things?**
 ///
 /// Use [`style`](OwoColorize::style) to apply a [`Style`]
-///
 pub trait OwoColorize: Sized {
     /// Set the foreground color generically
     ///
@@ -367,9 +373,10 @@ pub trait OwoColorize: Sized {
         strikethrough StrikeThroughDisplay,
     }
 
-    /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// Set the foreground color at runtime. Only use if you do not know which
+    /// color will be used at compile-time. If the color is constant, use
+    /// either [`OwoColorize::fg`](OwoColorize::fg) or a color-specific
+    /// method, such as [`OwoColorize::green`](OwoColorize::green),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -382,9 +389,10 @@ pub trait OwoColorize: Sized {
         FgDynColorDisplay(self, color)
     }
 
-    /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// Set the background color at runtime. Only use if you do not know what
+    /// color to use at compile-time. If the color is constant, use either
+    /// [`OwoColorize::bg`](OwoColorize::bg) or a color-specific method,
+    /// such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -433,11 +441,16 @@ pub trait OwoColorize: Sized {
         style.style(self)
     }
 
-    /// Apply a given transformation function to all formatters if the given stream
-    /// supports at least basic ANSI colors, allowing you to conditionally apply
-    /// given styles/colors.
+    /// Apply a given transformation function to all formatters if the given
+    /// stream supports at least basic ANSI colors, allowing you to
+    /// conditionally apply given styles/colors.
     ///
-    /// Requires the `supports-colors` feature.
+    /// Requires the `supports-colors` or `override` feature.
+    ///
+    /// If `supports-colors` is enabled `owo-colors` will try to determine the
+    /// terminal capabilities depending on the stream used, while with
+    /// `override` only the value set via [`set_override`] and [`with_override`]
+    /// is considered.
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, Stream};
@@ -449,7 +462,7 @@ pub trait OwoColorize: Sized {
     /// );
     /// ```
     #[must_use]
-    #[cfg(feature = "supports-colors")]
+    #[cfg(feature = "override")]
     fn if_supports_color<'a, Out, ApplyFn>(
         &'a self,
         stream: Stream,
@@ -462,24 +475,25 @@ pub trait OwoColorize: Sized {
     }
 }
 
-#[cfg(feature = "supports-colors")]
+#[cfg(feature = "override")]
 mod supports_colors;
 
+pub use colors::ansi_colors::AnsiColors;
+pub use colors::css::dynamic::CssColors;
+pub use colors::dynamic::Rgb;
+pub use colors::xterm::dynamic::XtermColors;
+#[cfg(feature = "override")]
+pub use overrides::{set_override, unset_override, with_override, Stream};
 #[cfg(feature = "supports-colors")]
-pub use {
-    overrides::{set_override, unset_override, with_override},
-    supports_color::Stream,
-    supports_colors::SupportsColorsDisplay,
-};
+pub use supports_colors::SupportsColorsDisplay;
 
-pub use colors::{
-    ansi_colors::AnsiColors, css::dynamic::CssColors, dynamic::Rgb, xterm::dynamic::XtermColors,
-};
-
-// TODO: figure out some wait to only implement for fmt::Display | fmt::Debug | ...
+// TODO: figure out some wait to only implement for fmt::Display | fmt::Debug |
+// ...
 impl<D: Sized> OwoColorize for D {}
 
-pub use {combo::ComboColorDisplay, dyn_colors::*, dyn_styles::*};
+pub use combo::ComboColorDisplay;
+pub use dyn_colors::*;
+pub use dyn_styles::*;
 
 /// Module for drop-in [`colored`](https://docs.rs/colored) support to aid in porting code from
 /// [`colored`](https://docs.rs/colored) to owo-colors.
@@ -497,11 +511,11 @@ pub use {combo::ComboColorDisplay, dyn_colors::*, dyn_styles::*};
 /// use owo_colors::colored::*;
 /// ```
 pub mod colored {
-    pub use crate::AnsiColors as Color;
-    pub use crate::OwoColorize;
+    pub use crate::{AnsiColors as Color, OwoColorize};
 
-    /// A couple of functions to enable and disable coloring similarly to `colored`
-    #[cfg(feature = "supports-colors")]
+    /// A couple of functions to enable and disable coloring similarly to
+    /// `colored`
+    #[cfg(feature = "override")]
     pub mod control {
         pub use crate::{set_override, unset_override};
     }

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -1,5 +1,22 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
+/// possible stream sources
+#[derive(Debug, Copy, Clone)]
+pub enum Stream {
+    Stdout,
+    Stderr,
+}
+
+#[cfg(feature = "supports-colors")]
+impl From<supports_color::Stream> for Stream {
+    fn from(value: supports_color::Stream) -> Self {
+        match value {
+            supports_color::Stream::Stdout => Self::Stdout,
+            supports_color::Stream::Stderr => Self::Stderr,
+        }
+    }
+}
+
 /// Set an override value for whether or not colors are supported using
 /// [`set_override`] while executing the closure provided.
 ///
@@ -10,7 +27,7 @@ use core::sync::atomic::{AtomicU8, Ordering};
 /// override the supported color set, without impacting previous configurations.
 ///
 /// ```
-/// # use supports_color::Stream;
+/// # use owo_colors::Stream;
 /// # use owo_colors::{OwoColorize, set_override, unset_override, with_override};
 /// # use owo_colors::colors::Black;
 /// #
@@ -24,7 +41,7 @@ use core::sync::atomic::{AtomicU8, Ordering};
 /// assert_eq!("example".if_supports_color(Stream::Stdout, |value| value.bg::<Black>()).to_string(), "example");
 /// # unset_override() // make sure that other doc tests are not impacted
 /// ```
-#[cfg(feature = "supports-colors")]
+#[cfg(feature = "override")]
 pub fn with_override<T, F: FnOnce() -> T>(enabled: bool, f: F) -> T {
     let previous = OVERRIDE.inner();
     OVERRIDE.set_force(enabled);
@@ -48,7 +65,7 @@ pub fn with_override<T, F: FnOnce() -> T>(enabled: bool, f: F) -> T {
 ///
 /// This behavior can be disabled using [`unset_override`], allowing
 /// `owo-colors` to return to inferring if colors are supported.
-#[cfg(feature = "supports-colors")]
+#[cfg(feature = "override")]
 pub fn set_override(enabled: bool) {
     OVERRIDE.set_force(enabled);
 }
@@ -59,7 +76,7 @@ pub fn set_override(enabled: bool) {
 /// supports colors.
 ///
 /// This override can be set using [`set_override`].
-#[cfg(feature = "supports-colors")]
+#[cfg(feature = "override")]
 pub fn unset_override() {
     OVERRIDE.unset();
 }

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -2,8 +2,12 @@ use core::sync::atomic::{AtomicU8, Ordering};
 
 /// possible stream sources
 #[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum Stream {
+    /// Standard output (stdout)
     Stdout,
+
+    /// Standard error (stderr)
     Stderr,
 }
 
@@ -13,6 +17,16 @@ impl From<supports_color::Stream> for Stream {
         match value {
             supports_color::Stream::Stdout => Self::Stdout,
             supports_color::Stream::Stderr => Self::Stderr,
+        }
+    }
+}
+
+#[cfg(feature = "supports-colors")]
+impl From<Stream> for supports_color::Stream {
+    fn from(value: Stream) -> Self {
+        match value {
+            Stream::Stdout => Self::Stdout,
+            Stream::Stderr => Self::Stderr,
         }
     }
 }

--- a/src/styled_list.rs
+++ b/src/styled_list.rs
@@ -1,8 +1,8 @@
-use crate::{dyn_styles::StyleFlags, Style, Styled};
-use core::{
-    fmt::{self, Display},
-    marker::PhantomData,
-};
+use core::fmt::{self, Display};
+use core::marker::PhantomData;
+
+use crate::dyn_styles::StyleFlags;
+use crate::{Style, Styled};
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -43,8 +43,8 @@ impl<T: Display> IsStyled for Styled<T> {
     }
 }
 
-/// A collection of [`Styled`] items that are displayed in such a way as to minimize the amount of characters
-/// that are written when displayed.
+/// A collection of [`Styled`] items that are displayed in such a way as to
+/// minimize the amount of characters that are written when displayed.
 ///
 /// ```rust
 /// use owo_colors::{Style, Styled, StyledList};
@@ -111,7 +111,8 @@ where
 }
 
 impl<'a> Style {
-    /// Returns an enum that indicates how the transition from one style to this style should be printed
+    /// Returns an enum that indicates how the transition from one style to this
+    /// style should be printed
     fn transition_from(&'a self, from: &Style) -> Transition<'a> {
         if self == from {
             return Transition::Noop;
@@ -183,6 +184,7 @@ pub type StyledVec<T> = StyledList<alloc::vec::Vec<Styled<T>>, Styled<T>>;
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::tests::assert_str;
 
     #[test]
     fn test_styled_list() {
@@ -194,9 +196,9 @@ mod test {
 
         let list = StyledList::from(list);
 
-        assert_eq!(
-            format!("{}", list),
-            "\x1b[31mred\x1b[32;3mgreen italic\x1b[0m\x1b[31;1mred bold\x1b[0m"
+        assert_str(
+            list,
+            "\x1b[31mred\x1b[32;3mgreen italic\x1b[0m\x1b[31;1mred bold\x1b[0m",
         );
     }
 
@@ -210,10 +212,7 @@ mod test {
 
         let list = StyledList::from(list);
 
-        assert_eq!(
-            format!("{}", list),
-            "\x1b[31mred\x1b[32;3mgreen italic\x1b[0mplain"
-        );
+        assert_str(list, "\x1b[31mred\x1b[32;3mgreen italic\x1b[0mplain");
     }
 
     #[test]

--- a/src/supports_colors.rs
+++ b/src/supports_colors.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 
-#[cfg(feature = "supports-colors")]
-/// A display wrapper which applies a transformation based on if the given stream supports
-/// colored terminal output
+#[cfg(feature = "override")]
+/// A display wrapper which applies a transformation based on if the given
+/// stream supports colored terminal output
 pub struct SupportsColorsDisplay<'a, InVal, Out, ApplyFn>(
     pub(crate) &'a InVal,
     pub(crate) ApplyFn,
@@ -23,6 +23,7 @@ macro_rules! impl_fmt_for {
                       F: Fn(&'a In) -> Out,
             {
                 #[inline(always)]
+                #[cfg(feature = "supports-colors")]
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let (force_enabled, force_disabled) = OVERRIDE.is_force_enabled_or_disabled();
                     if force_enabled || (
@@ -31,6 +32,17 @@ macro_rules! impl_fmt_for {
                             .unwrap_or(false)
                         && !force_disabled
                     ) {
+                        <Out as $trait>::fmt(&self.1(self.0), f)
+                    } else {
+                        <In as $trait>::fmt(self.0, f)
+                    }
+                }
+
+                #[inline(always)]
+                #[cfg(not(feature = "supports-colors"))]
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let (force_enabled, force_disabled) = OVERRIDE.is_force_enabled_or_disabled();
+                    if force_enabled || && !force_disabled {
                         <Out as $trait>::fmt(&self.1(self.0), f)
                     } else {
                         <In as $trait>::fmt(self.0, f)

--- a/src/supports_colors.rs
+++ b/src/supports_colors.rs
@@ -6,13 +6,13 @@ use core::fmt;
 pub struct SupportsColorsDisplay<'a, InVal, Out, ApplyFn>(
     pub(crate) &'a InVal,
     pub(crate) ApplyFn,
-    pub(crate) supports_color::Stream,
+    pub(crate) Stream,
 )
 where
     InVal: ?Sized,
     ApplyFn: Fn(&'a InVal) -> Out;
 
-use crate::OVERRIDE;
+use crate::{Stream, OVERRIDE};
 
 macro_rules! impl_fmt_for {
     ($($trait:path),* $(,)?) => {
@@ -27,7 +27,7 @@ macro_rules! impl_fmt_for {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let (force_enabled, force_disabled) = OVERRIDE.is_force_enabled_or_disabled();
                     if force_enabled || (
-                        supports_color::on_cached(self.2)
+                        supports_color::on_cached(self.2.into())
                             .map(|level| level.has_basic)
                             .unwrap_or(false)
                         && !force_disabled

--- a/src/supports_colors.rs
+++ b/src/supports_colors.rs
@@ -42,7 +42,7 @@ macro_rules! impl_fmt_for {
                 #[cfg(not(feature = "supports-colors"))]
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let (force_enabled, force_disabled) = OVERRIDE.is_force_enabled_or_disabled();
-                    if force_enabled || && !force_disabled {
+                    if force_enabled && !force_disabled {
                         <Out as $trait>::fmt(&self.1(self.0), f)
                     } else {
                         <In as $trait>::fmt(self.0, f)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,57 +1,99 @@
+use core::fmt;
+use core::fmt::{Display, Write};
+
 use super::colors::*;
 use super::OwoColorize;
 use crate::colors::css::Lavender;
 use crate::{AnsiColors, DynColors};
 
+struct BufferWriter<'a> {
+    pointer: &'a mut [u8],
+    offset: usize,
+}
+
+impl Write for BufferWriter<'_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        // only used during tests, therefore we can just assert
+        assert!(self.pointer.len() - self.offset >= s.len());
+
+        let bytes = s.as_bytes();
+        self.pointer[self.offset..self.offset + bytes.len()].copy_from_slice(bytes);
+        self.offset += bytes.len();
+
+        Ok(())
+    }
+}
+
+pub(crate) fn assert_str<T: Display>(lhs: T, rhs: &str) {
+    // allocate enough in our standard buffer for all examples
+    let mut buffer = [0u8; 256];
+    let mut writer = BufferWriter {
+        pointer: &mut buffer,
+        offset: 0,
+    };
+
+    write!(&mut writer, "{}", lhs).expect("able to write to buffer");
+    let length = writer.offset;
+
+    let lhs = core::str::from_utf8(&buffer[..length]).expect("should be valid utf8");
+
+    assert_eq!(lhs, rhs);
+}
+
+#[test]
+fn test_assert_str() {
+    assert_str("TEST", "TEST");
+}
+
+#[test]
+#[should_panic]
+fn test_assert_str_neq() {
+    assert_str("TEST123", "TEST");
+}
+
 #[test]
 fn test_fg() {
-    assert_eq!("test".fg::<Black>().to_string(), "\x1b[30mtest\x1b[39m");
-    assert_eq!("blah blah".red().to_string(), "\x1b[31mblah blah\x1b[39m");
+    assert_str("test".fg::<Black>(), "\x1b[30mtest\x1b[39m");
+    assert_str("blah blah".red(), "\x1b[31mblah blah\x1b[39m");
 }
 
 #[test]
 fn test_bg() {
-    assert_eq!("test".bg::<Black>().to_string(), "\x1b[40mtest\x1b[49m");
-    assert_eq!(
-        "blah blah".on_red().to_string(),
-        "\x1b[41mblah blah\x1b[49m"
-    );
+    assert_str("test".bg::<Black>(), "\x1b[40mtest\x1b[49m");
+    assert_str("blah blah".on_red(), "\x1b[41mblah blah\x1b[49m");
 }
 
 #[test]
 fn test_dyn_fg() {
-    assert_eq!(
-        "test".color(AnsiColors::Black).to_string(),
-        "\x1b[30mtest\x1b[39m"
-    );
-    assert_eq!(
-        "blah blah".color(AnsiColors::Red).to_string(),
-        "\x1b[31mblah blah\x1b[39m"
+    assert_str("test".color(AnsiColors::Black), "\x1b[30mtest\x1b[39m");
+    assert_str(
+        "blah blah".color(AnsiColors::Red),
+        "\x1b[31mblah blah\x1b[39m",
     );
 }
 
 #[test]
 fn test_dyn_bg() {
-    assert_eq!(
-        "test".on_color(AnsiColors::Black).to_string(),
-        "\x1b[40mtest\x1b[49m"
-    );
-    assert_eq!(
-        "blah blah".on_color(AnsiColors::Red).to_string(),
-        "\x1b[41mblah blah\x1b[49m"
+    assert_str("test".on_color(AnsiColors::Black), "\x1b[40mtest\x1b[49m");
+    assert_str(
+        "blah blah".on_color(AnsiColors::Red),
+        "\x1b[41mblah blah\x1b[49m",
     );
 }
 
 #[test]
 fn test_hex() {
-    assert_eq!(format!("{:08X}", 0xa.red()), "\x1b[31m0000000A\x1b[39m");
+    assert_str(
+        format_args!("{:08X}", 0xa.red()),
+        "\x1b[31m0000000A\x1b[39m",
+    );
 }
 
 #[test]
 fn test_css_name() {
-    assert_eq!(
-        "test".fg::<Lavender>().to_string(),
-        "\x1b[38;2;230;230;250mtest\x1b[39m"
+    assert_str(
+        "test".fg::<Lavender>(),
+        "\x1b[38;2;230;230;250mtest\x1b[39m",
     );
 }
 
@@ -74,10 +116,8 @@ fn test_parse() {
 
 #[test]
 fn default_color() {
-    assert_eq!(
-        format_args!("red red red {} no color", "default color".default_color())
-            .red()
-            .to_string(),
-        "\x1b[31mred red red \x1b[39mdefault color\x1b[39m no color\x1b[39m"
+    assert_str(
+        format_args!("red red red {} no color", "default color".default_color()).red(),
+        "\x1b[31mred red red \x1b[39mdefault color\x1b[39m no color\x1b[39m",
     );
 }


### PR DESCRIPTION
Implements #88.

This separates the `supports-colors` feature into three different features:
* `supports-colors`
* `std`
* `override`

The override methods (and `if_supports_color`) are now enabled with the `override` feature.

This also "fixes" #82 by introducing a new `Stream` type, essentially the same as `supports-colors`, but needs to be implemented as a new type as it is exposed when the `override` feature is enabled. (a `From` implementation is provided).

This also makes all tests no-std compatible by introducing a new helper: `assert_str`.

(all permutations also have been tested using `cargo hack test --feature-powerset`)