### PR TITLE
add white background to logo on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://jam1.re/img/rust_owo.svg" height="100"> Colors
+# <img style="background:white" src="https://jam1.re/img/rust_owo.svg" height="100"> Colors
 
 [![Current Crates.io Version](https://img.shields.io/crates/v/owo-colors.svg)](https://crates.io/crates/owo-colors)
 [![docs-rs](https://docs.rs/owo-colors/badge.svg)](https://docs.rs/owo-colors)


### PR DESCRIPTION
in dark mode the logo is almost invisible, this is a fix for that

![logo in dark mode](https://user-images.githubusercontent.com/672405/217971636-9eb89dd5-d739-45d8-bcaa-bc665a221978.png)
