### PR TITLE
Elide explicit lifetime annotations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ macro_rules! style_methods {
             #[$meta]
             #[must_use]
             #[inline(always)]
-            fn $name<'a>(&'a self) -> styles::$ty<'a, Self> {
+            fn $name(&self) -> styles::$ty<'_, Self> {
                 styles::$ty(self)
             }
          )*
@@ -189,14 +189,14 @@ macro_rules! color_methods {
             #[$fg_meta]
             #[must_use]
             #[inline(always)]
-            fn $fg_method<'a>(&'a self) -> FgColorDisplay<'a, colors::$color, Self> {
+            fn $fg_method(&self) -> FgColorDisplay<'_, colors::$color, Self> {
                 FgColorDisplay(self, PhantomData)
             }
 
             #[$bg_meta]
             #[must_use]
             #[inline(always)]
-            fn $bg_method<'a>(&'a self) -> BgColorDisplay<'a, colors::$color, Self> {
+            fn $bg_method(&self) -> BgColorDisplay<'_, colors::$color, Self> {
                 BgColorDisplay(self, PhantomData)
             }
          )*


### PR DESCRIPTION
CI is currently broken by clippy warnings on 1.70.0-nightly. Fix them.

```
warning: the following explicit lifetimes could be elided: 'a
   --> src/lib.rs:192:13
    |
192 |               fn $fg_method<'a>(&'a self) -> FgColorDisplay<'a, colors::$color, Self> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
287 | /     color_methods! {
288 | |         /// Change the foreground color to black
289 | |         /// Change the background color to black
290 | |         Black    black    on_black,
...   |
346 | |         BrightWhite    bright_white    on_bright_white,
347 | |     }
    | |_____- in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `#[warn(clippy::needless_lifetimes)]` on by default
    = note: this warning originates in the macro `color_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
help: elide the lifetimes
    |
192 -             fn $fg_method<'a>(&'a self) -> FgColorDisplay<'a, colors::$color, Self> {
192 +             fn $fg_method(&self) -> FgColorDisplay<'_, colors::$color, Self> {
    |
```