### PR TITLE
Raise MSRV to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.51.0
+          - 1.56.0
           - stable
           - nightly
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "owo-colors"
 version = "3.6.0"
-rust-version = "1.51"
+rust-version = "1.56"
 authors = ["jam1garner <8260240+jam1garner@users.noreply.github.com>"]
 edition = "2018"
 documentation = "https://docs.rs/owo-colors"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Current Crates.io Version](https://img.shields.io/crates/v/owo-colors.svg)](https://crates.io/crates/owo-colors)
 [![docs-rs](https://docs.rs/owo-colors/badge.svg)](https://docs.rs/owo-colors)
-![MSRV 1.51+](https://img.shields.io/badge/rustc-1.51+-blue.svg)
+![MSRV 1.56+](https://img.shields.io/badge/rustc-1.56+-blue.svg)
 ![Downloads](https://img.shields.io/crates/d/owo-colors)
 
 A zero-allocation no_std-compatible zero-cost way to add color to your Rust


### PR DESCRIPTION
The `banners` example already requires Rust 1.55 to build. Going one version further to 1.56 silences the (harmless) warning about the `rust-version` key in the Cargo.toml being unsupported and unlocks Rust 2021.

The example could instead be fixed to build with Rust 1.51, but don't bother and just bump the MSRV since 1.56 is already one and a half years old at this point.

---
Note: This will need to be rebased once https://github.com/jam1garner/owo-colors/pull/101 landed to get CI green.