### PR TITLE
Add a way to support both v1 and v2 of supports-colors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,12 @@ jobs:
         with:
           command: test
           args: --all-features --example all_xterm_colors --example colors --example dyn_colors --example override --example custom_colors --example extra_colors --example supports_color
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Run tests with feature powerset
+        # Note: you might think that we can also pass in `--exclude-all-features` here, but that
+        # isn't the case because if you pass in a --example, it doesn't run doctests. The below
+        # expression will run doctests as well.
+        run: cargo hack --feature-powerset

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ required-features = ["supports-colors"]
 
 [features]
 supports-colors = ["supports-color"]
+supports-colors-2 = ["supports-color-2"]
 alloc = []
 
 [dependencies]
 supports-color = { version = "1.3", optional = true }
+supports-color-2 = { package = "supports-color", version = "2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ supports-colors = ["supports-color"]
 alloc = []
 
 [dependencies]
-supports-color = { version = "2.0", optional = true }
+supports-color = { version = "1.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,10 @@ mod dyn_styles;
 mod styled_list;
 pub mod styles;
 
-#[cfg(feature = "supports-colors")]
+#[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
 mod overrides;
 
-#[cfg(feature = "supports-colors")]
+#[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
 pub(crate) use overrides::OVERRIDE;
 
 use core::fmt;
@@ -437,40 +437,65 @@ pub trait OwoColorize: Sized {
     /// supports at least basic ANSI colors, allowing you to conditionally apply
     /// given styles/colors.
     ///
-    /// Requires the `supports-colors` feature.
+    /// Requires the `supports-colors-2` feature, or the deprecated `supports-colors` feature.
     ///
     /// ```rust
-    /// use owo_colors::{OwoColorize, Stream};
+    /// use owo_colors::{OutputStream, OwoColorize};
     ///
     /// println!(
     ///     "{}",
     ///     "woah! error! if this terminal supports colors, it's blue"
-    ///         .if_supports_color(Stream::Stdout, |text| text.bright_blue())
+    ///         .if_supports_color(OutputStream::Stdout, |text| text.bright_blue())
     /// );
     /// ```
+    ///
+    /// This function also accepts `supports_color` version 2's `Stream`, and also the deprecated
+    /// `supports_color` version 1's `Stream`.
+    ///
+    /// ```rust
+    /// use owo_colors::OwoColorize;
+    /// #[cfg(feature = "supports-colors-2")]
+    /// use supports_color_2::Stream;
+    /// #[cfg(all(feature = "supports-colors", not(feature = "supports-colors-2")))]
+    /// use supports_color::Stream;
+    ///
+    /// println!(
+    ///    "{}",
+    ///    "woah! error! if this terminal supports colors, it's blue"
+    ///       .if_supports_color(Stream::Stdout, |text| text.bright_blue())
+    /// );
     #[must_use]
-    #[cfg(feature = "supports-colors")]
+    #[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
     fn if_supports_color<'a, Out, ApplyFn>(
         &'a self,
-        stream: Stream,
+        stream: impl Into<OutputStream>,
         apply: ApplyFn,
     ) -> SupportsColorsDisplay<'a, Self, Out, ApplyFn>
     where
         ApplyFn: Fn(&'a Self) -> Out,
     {
-        SupportsColorsDisplay(self, apply, stream)
+        SupportsColorsDisplay(self, apply, stream.into())
     }
 }
 
-#[cfg(feature = "supports-colors")]
+#[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
 mod supports_colors;
 
-#[cfg(feature = "supports-colors")]
+#[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
 pub use {
     overrides::{set_override, unset_override, with_override},
-    supports_color::Stream,
-    supports_colors::SupportsColorsDisplay,
+    supports_colors::{OutputStream, SupportsColorsDisplay},
 };
+
+/// Exports cannot be deprecated yet: https://github.com/rust-lang/rust/issues/30827 but this is put
+/// in here to enable deprecations as soon as that is enabled.
+#[cfg(feature = "supports-colors")]
+#[deprecated(
+    since = "3.7.0",
+    note = "Use supports-colors-2 and OutputStream instead of Stream"
+)]
+#[doc(no_inline)]
+pub use supports_color::Stream;
 
 pub use colors::{
     ansi_colors::AnsiColors, css::dynamic::CssColors, dynamic::Rgb, xterm::dynamic::XtermColors,

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -10,21 +10,20 @@ use core::sync::atomic::{AtomicU8, Ordering};
 /// override the supported color set, without impacting previous configurations.
 ///
 /// ```
-/// # use supports_color::Stream;
-/// # use owo_colors::{OwoColorize, set_override, unset_override, with_override};
+/// # use owo_colors::{OutputStream, OwoColorize, set_override, unset_override, with_override};
 /// # use owo_colors::colors::Black;
 /// #
 /// set_override(false);
-/// assert_eq!("example".if_supports_color(Stream::Stdout, |value| value.bg::<Black>()).to_string(), "example");
+/// assert_eq!("example".if_supports_color(OutputStream::Stdout, |value| value.bg::<Black>()).to_string(), "example");
 ///
 /// with_override(true, || {
-///     assert_eq!("example".if_supports_color(Stream::Stdout, |value| value.bg::<Black>()).to_string(), "\x1b[40mexample\x1b[49m");
+///     assert_eq!("example".if_supports_color(OutputStream::Stdout, |value| value.bg::<Black>()).to_string(), "\x1b[40mexample\x1b[49m");
 /// });
 ///
-/// assert_eq!("example".if_supports_color(Stream::Stdout, |value| value.bg::<Black>()).to_string(), "example");
+/// assert_eq!("example".if_supports_color(OutputStream::Stdout, |value| value.bg::<Black>()).to_string(), "example");
 /// # unset_override() // make sure that other doc tests are not impacted
 /// ```
-#[cfg(feature = "supports-colors")]
+#[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
 pub fn with_override<T, F: FnOnce() -> T>(enabled: bool, f: F) -> T {
     let previous = OVERRIDE.inner();
     OVERRIDE.set_force(enabled);
@@ -48,7 +47,7 @@ pub fn with_override<T, F: FnOnce() -> T>(enabled: bool, f: F) -> T {
 ///
 /// This behavior can be disabled using [`unset_override`], allowing
 /// `owo-colors` to return to inferring if colors are supported.
-#[cfg(feature = "supports-colors")]
+#[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
 pub fn set_override(enabled: bool) {
     OVERRIDE.set_force(enabled);
 }
@@ -59,7 +58,7 @@ pub fn set_override(enabled: bool) {
 /// supports colors.
 ///
 /// This override can be set using [`set_override`].
-#[cfg(feature = "supports-colors")]
+#[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
 pub fn unset_override() {
     OVERRIDE.unset();
 }

--- a/src/supports_colors.rs
+++ b/src/supports_colors.rs
@@ -1,12 +1,58 @@
 use core::fmt;
 
+mod private {
+    pub(super) trait Sealed {}
+}
+
+/// A possible stream source.
+///
+/// This can be used
+#[derive(Clone, Copy, Debug)]
+pub enum OutputStream {
+    /// Standard output.
+    Stdout,
+
+    /// Standard error.
+    Stderr,
+
+    /// Standard input. Only used to retain compatibility with supports-colors v1.
+    #[doc(hidden)]
+    #[deprecated(
+        since = "3.7.0",
+        note = "This is only used to retain compatibility with supports-colors v1."
+    )]
+    Stdin,
+}
+
 #[cfg(feature = "supports-colors")]
+impl From<supports_color::Stream> for OutputStream {
+    fn from(stream: supports_color::Stream) -> Self {
+        match stream {
+            supports_color::Stream::Stdout => OutputStream::Stdout,
+            supports_color::Stream::Stderr => OutputStream::Stderr,
+            #[allow(deprecated)]
+            supports_color::Stream::Stdin => OutputStream::Stdin,
+        }
+    }
+}
+
+#[cfg(feature = "supports-colors-2")]
+impl From<supports_color_2::Stream> for OutputStream {
+    fn from(stream: supports_color_2::Stream) -> Self {
+        match stream {
+            supports_color_2::Stream::Stdout => OutputStream::Stdout,
+            supports_color_2::Stream::Stderr => OutputStream::Stderr,
+        }
+    }
+}
+
+#[cfg(any(feature = "supports-colors", feature = "supports-colors-2"))]
 /// A display wrapper which applies a transformation based on if the given stream supports
 /// colored terminal output
 pub struct SupportsColorsDisplay<'a, InVal, Out, ApplyFn>(
     pub(crate) &'a InVal,
     pub(crate) ApplyFn,
-    pub(crate) supports_color::Stream,
+    pub(crate) OutputStream,
 )
 where
     InVal: ?Sized,
@@ -25,12 +71,7 @@ macro_rules! impl_fmt_for {
                 #[inline(always)]
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let (force_enabled, force_disabled) = OVERRIDE.is_force_enabled_or_disabled();
-                    if force_enabled || (
-                        supports_color::on_cached(self.2)
-                            .map(|level| level.has_basic)
-                            .unwrap_or(false)
-                        && !force_disabled
-                    ) {
+                    if force_enabled || (on_cached(self.2) && !force_disabled) {
                         <Out as $trait>::fmt(&self.1(self.0), f)
                     } else {
                         <In as $trait>::fmt(self.0, f)
@@ -39,6 +80,36 @@ macro_rules! impl_fmt_for {
             }
         )*
     };
+}
+
+/// Use supports-colors v2 if it is enabled.
+#[cfg(feature = "supports-colors-2")]
+fn on_cached(stream: OutputStream) -> bool {
+    let stream = match stream {
+        OutputStream::Stdout => supports_color_2::Stream::Stdout,
+        OutputStream::Stderr => supports_color_2::Stream::Stderr,
+        #[allow(deprecated)]
+        OutputStream::Stdin => {
+            panic!("stdin is not supported if supports-colors-2 is enabled")
+        }
+    };
+    supports_color_2::on_cached(stream)
+        .map(|level| level.has_basic)
+        .unwrap_or(false)
+}
+
+/// Use supports-colors v1 if v2 is not enabled.
+#[cfg(all(feature = "supports-color", not(feature = "supports-colors-2")))]
+fn on_cached(stream: OutputStream) -> bool {
+    let stream = match stream {
+        OutputStream::Stdout => supports_color::Stream::Stdout,
+        OutputStream::Stderr => supports_color::Stream::Stderr,
+        #[allow(deprecated)]
+        OutputStream::Stdin => supports_color::Stream::Stdin,
+    };
+    supports_color::on_cached(stream)
+        .map(|level| level.has_basic)
+        .unwrap_or(false)
 }
 
 impl_fmt_for! {


### PR DESCRIPTION
Also deprecate supports-color v1 to the greatest extent possible.

Fixes https://github.com/jam1garner/owo-colors/issues/114.