### PR TITLE
Fix typos in documentation and test code

### DIFF
--- a/src/combo.rs
+++ b/src/combo.rs
@@ -473,19 +473,19 @@ mod tests {
     }
 
     #[test]
-    fn fg_overide() {
+    fn fg_override() {
         let test = "test".green().yellow().red().on_blue();
         assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
-    fn bg_overide() {
+    fn bg_override() {
         let test = "test".on_green().on_yellow().on_blue().red();
         assert_eq!(test.to_string(), "\x1b[31;44mtest\x1b[0m");
     }
 
     #[test]
-    fn multiple_overide() {
+    fn multiple_override() {
         let test = "test"
             .on_green()
             .on_yellow()

--- a/src/dyn_styles.rs
+++ b/src/dyn_styles.rs
@@ -263,7 +263,7 @@ impl Style {
         (dimmed, set_dimmed),
         /// Make the text italicized
         (italic, set_italic),
-        /// Make the text italicized
+        /// Make the text underlined
         (underline, set_underline),
         /// Make the text blink
         (blink, set_blink),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ pub trait OwoColorize: Sized {
         dimmed DimDisplay,
         /// Make the text italicized
         italic ItalicDisplay,
-        /// Make the text italicized
+        /// Make the text underlined
         underline UnderlineDisplay,
         /// Make the text blink
         blink BlinkDisplay,


### PR DESCRIPTION
I was reading through the documentation and noticed that the doc comment for [underline](https://docs.rs/owo-colors/3.5.0/owo_colors/struct.Style.html#method.underline) incorrectly said "italicized". 

Since I decided to make a PR to fix the docs, I figured that I should run the [typos](https://crates.io/crates/typos) crate while I'm here and fix any typos that it found.