### PR TITLE
Fix `clippy` and `doc` warnings

### DIFF
--- a/src/combo.rs
+++ b/src/combo.rs
@@ -73,8 +73,8 @@ macro_rules! color_methods {
             Fg: Color,
         {
             /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-            /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-            /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+            /// compile-time. If the color is constant, use either [`OwoColorize::fg`] or
+            /// a color-specific method, such as [`OwoColorize::green`],
             ///
             /// ```rust
             /// use owo_colors::{OwoColorize, AnsiColors};
@@ -89,8 +89,8 @@ macro_rules! color_methods {
             }
 
             /// Set the background color at runtime. Only use if you do not know what color to use at
-            /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-            /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+            /// compile-time. If the color is constant, use either [`OwoColorize::bg`] or
+            /// a color-specific method, such as [`OwoColorize::on_yellow`],
             ///
             /// ```rust
             /// use owo_colors::{OwoColorize, AnsiColors};
@@ -148,8 +148,8 @@ macro_rules! color_methods {
             Bg: Color,
         {
             /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-            /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-            /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+            /// compile-time. If the color is constant, use either [`OwoColorize::fg`] or
+            /// a color-specific method, such as [`OwoColorize::green`],
             ///
             /// ```rust
             /// use owo_colors::{OwoColorize, AnsiColors};
@@ -164,8 +164,8 @@ macro_rules! color_methods {
             }
 
             /// Set the background color at runtime. Only use if you do not know what color to use at
-            /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-            /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+            /// compile-time. If the color is constant, use either [`OwoColorize::bg`] or
+            /// a color-specific method, such as [`OwoColorize::on_yellow`],
             ///
             /// ```rust
             /// use owo_colors::{OwoColorize, AnsiColors};
@@ -224,8 +224,8 @@ macro_rules! color_methods {
             Bg: Color,
         {
             /// Set the background color at runtime. Only use if you do not know what color to use at
-            /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-            /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+            /// compile-time. If the color is constant, use either [`OwoColorize::bg`] or
+            /// a color-specific method, such as [`OwoColorize::on_yellow`],
             ///
             /// ```rust
             /// use owo_colors::{OwoColorize, AnsiColors};
@@ -240,8 +240,8 @@ macro_rules! color_methods {
             }
 
             /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-            /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-            /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+            /// compile-time. If the color is constant, use either [`OwoColorize::fg`] or
+            /// a color-specific method, such as [`OwoColorize::green`],
             ///
             /// ```rust
             /// use owo_colors::{OwoColorize, AnsiColors};
@@ -356,8 +356,8 @@ color_methods! {
 
 impl<'a, Fg: DynColor, T> FgDynColorDisplay<'a, Fg, T> {
     /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// compile-time. If the color is constant, use either [`OwoColorize::bg`] or
+    /// a color-specific method, such as [`OwoColorize::on_yellow`],
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -370,8 +370,8 @@ impl<'a, Fg: DynColor, T> FgDynColorDisplay<'a, Fg, T> {
     }
 
     /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// compile-time. If the color is constant, use either [`OwoColorize::fg`] or
+    /// a color-specific method, such as [`OwoColorize::green`],
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -386,8 +386,8 @@ impl<'a, Fg: DynColor, T> FgDynColorDisplay<'a, Fg, T> {
 
 impl<'a, Bg: DynColor, T> BgDynColorDisplay<'a, Bg, T> {
     /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// compile-time. If the color is constant, use either [`OwoColorize::bg`] or
+    /// a color-specific method, such as [`OwoColorize::on_yellow`],
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -400,8 +400,8 @@ impl<'a, Bg: DynColor, T> BgDynColorDisplay<'a, Bg, T> {
     }
 
     /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// compile-time. If the color is constant, use either [`OwoColorize::fg`] or
+    /// a color-specific method, such as [`OwoColorize::green`],
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -416,8 +416,8 @@ impl<'a, Bg: DynColor, T> BgDynColorDisplay<'a, Bg, T> {
 
 impl<'a, Fg: DynColor, Bg: DynColor, T> ComboDynColorDisplay<'a, Fg, Bg, T> {
     /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// compile-time. If the color is constant, use either [`OwoColorize::bg`] or
+    /// a color-specific method, such as [`OwoColorize::on_yellow`],
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -430,8 +430,8 @@ impl<'a, Fg: DynColor, Bg: DynColor, T> ComboDynColorDisplay<'a, Fg, Bg, T> {
     }
 
     /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// compile-time. If the color is constant, use either [`OwoColorize::fg`] or
+    /// a color-specific method, such as [`OwoColorize::green`],
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-//! |**Quick Links**|[`OwoColorize`](OwoColorize)|[`Style`]|[`StyledList`]|[`github`](https://github.com/jam1garner/owo-colors)|
+//! |**Quick Links**|[`OwoColorize`]|[`Style`]|[`StyledList`]|[`github`](https://github.com/jam1garner/owo-colors)|
 //! |-|-|-|-|-|
 //!
 //! ---
 //!
-//! This crate provides [`OwoColorize`](OwoColorize), an extension trait for colorizing a
+//! This crate provides [`OwoColorize`], an extension trait for colorizing a
 //! given type.
 //!
 //! ## Example
@@ -11,12 +11,10 @@
 //! ```rust
 //! use owo_colors::OwoColorize;
 //!
-//! fn main() {
-//!     // Foreground colors
-//!     println!("My number is {:#x}!", 10.green());
-//!     // Background colors
-//!     println!("My number is not {}!", 4.on_red());
-//! }
+//! // Foreground colors
+//! println!("My number is {:#x}!", 10.green());
+//! // Background colors
+//! println!("My number is not {}!", 4.on_red());
 //! ```
 //!
 //! ## Generically color
@@ -25,10 +23,8 @@
 //! use owo_colors::OwoColorize;
 //! use owo_colors::colors::*;
 //!
-//! fn main() {
-//!     // Generically color
-//!     println!("My number might be {}!", 4.fg::<Black>().bg::<Yellow>());
-//! }
+//! // Generically color
+//! println!("My number might be {}!", 4.fg::<Black>().bg::<Yellow>());
 //! ```
 //!
 //! ## Stylize
@@ -94,8 +90,8 @@ pub(crate) use overrides::OVERRIDE;
 use core::fmt;
 use core::marker::PhantomData;
 
-/// A trait for describing a type which can be used with [`FgColorDisplay`](FgColorDisplay) or
-/// [`BgColorDisplay`](BgColorDisplay)
+/// A trait for describing a type which can be used with [`FgColorDisplay`] or
+/// [`BgColorDisplay`]
 pub trait Color {
     /// The ANSI format code for setting this color as the foreground
     const ANSI_FG: &'static str;
@@ -121,8 +117,8 @@ pub trait Color {
     fn into_dyncolors() -> crate::DynColors;
 }
 
-/// A trait describing a runtime-configurable color which can displayed using [`FgDynColorDisplay`](FgDynColorDisplay)
-/// or [`BgDynColorDisplay`](BgDynColorDisplay). If your color will be known at compile time it
+/// A trait describing a runtime-configurable color which can displayed using [`FgDynColorDisplay`]
+/// or [`BgDynColorDisplay`]. If your color will be known at compile time it
 /// is recommended you avoid this.
 pub trait DynColor {
     /// A function to output a ANSI code to a formatter to set the foreground to this color
@@ -146,13 +142,13 @@ pub trait DynColor {
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// with the addition of changing the foreground color. Recommended to be constructed using
-/// [`OwoColorize`](OwoColorize).
+/// [`OwoColorize`].
 #[repr(transparent)]
 pub struct FgColorDisplay<'a, C: Color, T>(&'a T, PhantomData<C>);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// with the addition of changing the background color. Recommended to be constructed using
-/// [`OwoColorize`](OwoColorize).
+/// [`OwoColorize`].
 #[repr(transparent)]
 pub struct BgColorDisplay<'a, C: Color, T>(&'a T, PhantomData<C>);
 
@@ -368,8 +364,8 @@ pub trait OwoColorize: Sized {
     }
 
     /// Set the foreground color at runtime. Only use if you do not know which color will be used at
-    /// compile-time. If the color is constant, use either [`OwoColorize::fg`](OwoColorize::fg) or
-    /// a color-specific method, such as [`OwoColorize::green`](OwoColorize::green),
+    /// compile-time. If the color is constant, use either [`OwoColorize::fg`] or
+    /// a color-specific method, such as [`OwoColorize::green`],
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};
@@ -383,8 +379,8 @@ pub trait OwoColorize: Sized {
     }
 
     /// Set the background color at runtime. Only use if you do not know what color to use at
-    /// compile-time. If the color is constant, use either [`OwoColorize::bg`](OwoColorize::bg) or
-    /// a color-specific method, such as [`OwoColorize::on_yellow`](OwoColorize::on_yellow),
+    /// compile-time. If the color is constant, use either [`OwoColorize::bg`] or
+    /// a color-specific method, such as [`OwoColorize::on_yellow`],
     ///
     /// ```rust
     /// use owo_colors::{OwoColorize, AnsiColors};


### PR DESCRIPTION
This fixes a couple `clippy` warnings ("needless `fn main` in doctest") and a bunch of `doc` warnings ("redundant link target").