### PR TITLE
Make most of the API const-friendly

### DIFF
--- a/examples/const_colors.rs
+++ b/examples/const_colors.rs
@@ -1,0 +1,61 @@
+//! Example demonstrating colors in const contexts.
+
+use owo_colors::{colors::*, styles::*, *};
+
+const GREEN_TEXT: FgColorDisplay<Green, str> = FgColorDisplay::new("green text");
+const RED_BG_TEXT: BgColorDisplay<Red, str> = BgColorDisplay::new("red background");
+const COMBO_TEXT: ComboColorDisplay<Blue, White, str> =
+    ComboColorDisplay::new("blue text on white background");
+const DYN_RED_TEXT: FgDynColorDisplay<AnsiColors, str> =
+    FgDynColorDisplay::new("red text (dynamic)", AnsiColors::Red);
+const DYN_GREEN_BG_TEXT: BgDynColorDisplay<AnsiColors, str> =
+    BgDynColorDisplay::new("green background (dynamic)", AnsiColors::Green);
+const COMBO_DYN_TEXT: ComboDynColorDisplay<XtermColors, XtermColors, str> =
+    ComboDynColorDisplay::new(
+        "blue text on lilac background (dynamic)",
+        XtermColors::BlueRibbon,
+        XtermColors::WistfulLilac,
+    );
+
+const BOLD_TEXT: BoldDisplay<str> = BoldDisplay("bold text");
+const DIM_TEXT: DimDisplay<str> = DimDisplay("dim text");
+const ITALIC_TEXT: ItalicDisplay<str> = ItalicDisplay("italic text");
+const UNDERLINE_TEXT: UnderlineDisplay<str> = UnderlineDisplay("underlined text");
+const BLINK_TEXT: BlinkDisplay<str> = BlinkDisplay("blinking text");
+const BLINK_FAST_TEXT: BlinkFastDisplay<str> = BlinkFastDisplay("fast blinking text");
+const REVERSED_TEXT: ReversedDisplay<str> = ReversedDisplay("reversed text");
+const HIDDEN_TEXT: HiddenDisplay<str> = HiddenDisplay("hidden text");
+const STRIKETHROUGH_TEXT: StrikeThroughDisplay<str> = StrikeThroughDisplay("strikethrough text");
+
+const STYLED_TEXT: Styled<&'static str> = Style::new()
+    .bold()
+    .italic()
+    .red()
+    .style("bold and italic red text (dynamically styled)");
+const STYLED_TEXT_2: Styled<&'static str> = Style::new()
+    .effect(Effect::Underline)
+    .effects(&[Effect::Dimmed, Effect::Strikethrough])
+    .green()
+    .style("underlined, dimmed and strikethrough green text (dynamically styled)");
+
+fn main() {
+    println!("{}", GREEN_TEXT);
+    println!("{}", RED_BG_TEXT);
+    println!("{}", COMBO_TEXT);
+    println!("{}", DYN_RED_TEXT);
+    println!("{}", DYN_GREEN_BG_TEXT);
+    println!("{}", COMBO_DYN_TEXT);
+
+    println!("{}", BOLD_TEXT);
+    println!("{}", DIM_TEXT);
+    println!("{}", ITALIC_TEXT);
+    println!("{}", UNDERLINE_TEXT);
+    println!("{}", BLINK_TEXT);
+    println!("{}", BLINK_FAST_TEXT);
+    println!("{}", REVERSED_TEXT);
+    println!("{}", HIDDEN_TEXT);
+    println!("{}", STRIKETHROUGH_TEXT);
+
+    println!("{}", STYLED_TEXT);
+    println!("{}", STYLED_TEXT_2);
+}

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -127,7 +127,7 @@ colors! {
 macro_rules! impl_fmt_for {
     ($($trait:path),* $(,)?) => {
         $(
-            impl<'a, Color: crate::Color, T: $trait> $trait for FgColorDisplay<'a, Color, T> {
+            impl<'a, Color: crate::Color, T: ?Sized + $trait> $trait for FgColorDisplay<'a, Color, T> {
                 #[inline(always)]
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     f.write_str(Color::ANSI_FG)?;
@@ -136,7 +136,7 @@ macro_rules! impl_fmt_for {
                 }
             }
 
-            impl<'a, Color: crate::Color, T: $trait> $trait for BgColorDisplay<'a, Color, T> {
+            impl<'a, Color: crate::Color, T: ?Sized + $trait> $trait for BgColorDisplay<'a, Color, T> {
                 #[inline(always)]
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     f.write_str(Color::ANSI_BG)?;
@@ -163,7 +163,7 @@ impl_fmt_for! {
 macro_rules! impl_fmt_for_dyn {
     ($($trait:path),* $(,)?) => {
         $(
-            impl<'a, Color: crate::DynColor, T: $trait> $trait for FgDynColorDisplay<'a, Color, T> {
+            impl<'a, Color: crate::DynColor, T: ?Sized + $trait> $trait for FgDynColorDisplay<'a, Color, T> {
                 #[inline(always)]
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     (self.1).fmt_ansi_fg(f)?;
@@ -172,7 +172,7 @@ macro_rules! impl_fmt_for_dyn {
                 }
             }
 
-            impl<'a, Color: crate::DynColor, T: $trait> $trait for BgDynColorDisplay<'a, Color, T> {
+            impl<'a, Color: crate::DynColor, T: ?Sized + $trait> $trait for BgDynColorDisplay<'a, Color, T> {
                 #[inline(always)]
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     (self.1).fmt_ansi_bg(f)?;

--- a/src/combo.rs
+++ b/src/combo.rs
@@ -10,9 +10,10 @@ use crate::OwoColorize;
 /// A wrapper type which applies both a foreground and background color
 pub struct ComboColorDisplay<'a, Fg: Color, Bg: Color, T>(&'a T, PhantomData<(Fg, Bg)>);
 
-/// Wrapper around a type which implements all the formatters the wrapped type does,
-/// with the addition of changing the foreground and background color. Is not recommended
-/// unless compile-time coloring is not an option.
+/// Wrapper around a type which implements all the formatters the wrapped type does, with the
+/// addition of changing the foreground and background color.
+///
+/// If compile-time coloring is an option, consider using [`ComboColorDisplay`] instead.
 pub struct ComboDynColorDisplay<'a, Fg: DynColor, Bg: DynColor, T>(&'a T, Fg, Bg);
 
 macro_rules! impl_fmt_for_combo {

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -7,7 +7,7 @@ use crate::OwoColorize;
 macro_rules! impl_fmt_for_style {
     ($(($ty:ident, $trait:path, $ansi:literal)),* $(,)?) => {
         $(
-            impl<'a, T: $trait> $trait for $ty<'a, T> {
+            impl<'a, T: ?Sized + $trait> $trait for $ty<'a, T> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     f.write_str($ansi)?;
                     <_ as $trait>::fmt(&self.0, f)?;
@@ -22,52 +22,52 @@ macro_rules! impl_fmt_for_style {
 /// with the addition of boldening it. Recommended to be constructed using
 /// [`OwoColorize`](OwoColorize::bold).
 #[repr(transparent)]
-pub struct BoldDisplay<'a, T>(pub &'a T);
+pub struct BoldDisplay<'a, T: ?Sized>(pub &'a T);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// with the addition of dimming it. Recommended to be constructed using
 /// [`OwoColorize`](OwoColorize::dimmed).
 #[repr(transparent)]
-pub struct DimDisplay<'a, T>(pub &'a T);
+pub struct DimDisplay<'a, T: ?Sized>(pub &'a T);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// with the addition of italics. Recommended to be constructed using
 /// [`OwoColorize`](OwoColorize::italic).
 #[repr(transparent)]
-pub struct ItalicDisplay<'a, T>(pub &'a T);
+pub struct ItalicDisplay<'a, T: ?Sized>(pub &'a T);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// while underlining it. Recommended to be constructed using
 /// [`OwoColorize`](OwoColorize::underline).
 #[repr(transparent)]
-pub struct UnderlineDisplay<'a, T>(pub &'a T);
+pub struct UnderlineDisplay<'a, T: ?Sized>(pub &'a T);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// while blinking. Recommended to be constructed using
 /// [`OwoColorize`](OwoColorize::blink).
 #[repr(transparent)]
-pub struct BlinkDisplay<'a, T>(pub &'a T);
+pub struct BlinkDisplay<'a, T: ?Sized>(pub &'a T);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// with the addition of making it blink fast. Use [`OwoColorize`](OwoColorize::blink_fast)
 #[repr(transparent)]
-pub struct BlinkFastDisplay<'a, T>(pub &'a T);
+pub struct BlinkFastDisplay<'a, T: ?Sized>(pub &'a T);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// with the addition of swapping fg and bg colors. Use [`OwoColorize`](OwoColorize::reversed)
 #[repr(transparent)]
-pub struct ReversedDisplay<'a, T>(pub &'a T);
+pub struct ReversedDisplay<'a, T: ?Sized>(pub &'a T);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// with the addition of hiding the text. Use [`OwoColorize`](OwoColorize::hidden).
 #[repr(transparent)]
-pub struct HiddenDisplay<'a, T>(pub &'a T);
+pub struct HiddenDisplay<'a, T: ?Sized>(pub &'a T);
 
 /// Transparent wrapper around a type which implements all the formatters the wrapped type does,
 /// crossed out. Recommended to be constructed using
 /// [`OwoColorize`](OwoColorize::strikethrough).
 #[repr(transparent)]
-pub struct StrikeThroughDisplay<'a, T>(pub &'a T);
+pub struct StrikeThroughDisplay<'a, T: ?Sized>(pub &'a T);
 
 impl_fmt_for_style! {
     // Bold


### PR DESCRIPTION
Since owo-colors does most of its work via the type system, it makes sense for it to be possible to construct the types at compile time. I've rewritten a few methods to make them const friendly (no &mut refs...), but otherwise this appears to work great.

One change I've made is to drop the `Sized` requirement on the types that are only accessed via pointer indirection. This allows users to write types like `FgColorDisplay<Green, str>` which feels great. I can't drop the `Sized` requirement on `OwoColorize` due to API compat, though, sadly.

Whatever bits are left out are not possible to convert over to const currently -- I've added comments explaining why. But enough of the API is available (including dynamic styles!) that I think most user needs will be met through this.

Closes #62.