### PR TITLE
Render `Stream` docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,6 @@ pub use {
 };
 
 #[cfg(feature = "supports-colors")]
-#[doc(no_inline)]
 pub use supports_colors::Stream;
 
 pub use colors::{

--- a/src/supports_colors.rs
+++ b/src/supports_colors.rs
@@ -13,8 +13,6 @@ where
     ApplyFn: Fn(&'a InVal) -> Out;
 
 /// A possible stream source.
-///
-/// This can be used
 #[derive(Clone, Copy, Debug)]
 pub enum Stream {
     /// Standard output.


### PR DESCRIPTION
`supports_colors` is a private module, `Stream` is a no-inline reexport. As a result, docs.rs does not render any sort of documentation about what `Stream` is. I'm tentatively removing `doc(no_inline)` as I think this is the right fix.