### PR TITLE
serde support? (pretty please?)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ required-features = ["supports-colors"]
 # the nonfunctional "supports-color" feature.
 supports-colors = ["dep:supports-color-2", "supports-color"]
 alloc = []
+serde = ["dep:serde"]
 
 [dependencies]
 supports-color-2 = { package = "supports-color", version = "2.0", optional = true }
 supports-color = { version = "3.0.0", optional = true }
+serde = { version = "1.0.218", features = ["derive"], optional = true, default-features = false }

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -17,6 +17,7 @@ macro_rules! colors {
             /// or [`OwoColorize::on_color`](OwoColorize::on_color)
             #[allow(missing_docs)]
             #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+            #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             pub enum AnsiColors {
                 $(
                     $color,
@@ -78,6 +79,7 @@ macro_rules! colors {
 
         $(
             /// A color for use with [`OwoColorize`](crate::OwoColorize)'s `fg` and `bg` methods.
+            #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             pub struct $color;
 
             impl crate::Color for $color {

--- a/src/colors/css.rs
+++ b/src/colors/css.rs
@@ -13,6 +13,7 @@ macro_rules! css_color_types {
             /// or [`OwoColorize::on_color`](OwoColorize::on_color)
             #[allow(missing_docs)]
             #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+            #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             pub enum CssColors {
                 $($name,)*
             }

--- a/src/colors/dynamic.rs
+++ b/src/colors/dynamic.rs
@@ -7,6 +7,7 @@ use crate::OwoColorize;
 /// Available RGB colors for use with [`OwoColorize::color`](OwoColorize::color)
 /// or [`OwoColorize::on_color`](OwoColorize::on_color)
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rgb(pub u8, pub u8, pub u8);
 
 impl DynColor for Rgb {

--- a/src/colors/xterm.rs
+++ b/src/colors/xterm.rs
@@ -12,6 +12,7 @@ macro_rules! xterm_colors {
             /// Available Xterm colors for use with [`OwoColorize::color`](OwoColorize::color)
             /// or [`OwoColorize::on_color`](OwoColorize::on_color)
             #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+            #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             pub enum XtermColors {
                 $(
                     #[allow(missing_docs)]
@@ -94,6 +95,7 @@ macro_rules! xterm_colors {
 
         $(
             #[allow(missing_docs)]
+            #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             pub struct $name;
 
             impl crate::Color for $name {

--- a/src/dyn_colors.rs
+++ b/src/dyn_colors.rs
@@ -10,6 +10,7 @@ use core::fmt;
 /// allowing for multiple types of colors to be used at runtime.
 #[allow(missing_docs)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DynColors {
     Ansi(AnsiColors),
     Css(CssColors),

--- a/src/dyn_styles.rs
+++ b/src/dyn_styles.rs
@@ -7,6 +7,7 @@ use crate::OwoColorize;
 /// A runtime-configurable text effect for use with [`Style`]
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Effect {
     Bold,
     Dimmed,
@@ -57,6 +58,7 @@ macro_rules! style_methods {
 const _: () = (); // workaround for syntax highlighting bug
 
 /// A wrapper type which applies a [`Style`] when displaying the inner type
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Styled<T> {
     /// The target value to be styled
     pub(crate) target: T,
@@ -80,6 +82,7 @@ pub struct Styled<T> {
 /// println!("{}", "red text, white background, struck through".style(my_style));
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Style {
     pub(crate) fg: Option<DynColors>,
     pub(crate) bg: Option<DynColors>,
@@ -89,6 +92,7 @@ pub struct Style {
 
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct StyleFlags(pub(crate) u8);
 
 const DIMMED_SHIFT: u8 = 0;

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -65,6 +65,7 @@ pub fn unset_override() {
 
 pub(crate) static OVERRIDE: Override = Override::none();
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct Override(AtomicU8);
 
 const FORCE_MASK: u8 = 0b10;

--- a/src/styled_list.rs
+++ b/src/styled_list.rs
@@ -61,6 +61,7 @@ impl<T: Display> IsStyled for Styled<T> {
 ///
 /// assert!(styled_length < normal_length);
 /// ```
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StyledList<T, U>(pub T, PhantomData<fn(U)>)
 where
     T: AsRef<[U]>,


### PR DESCRIPTION
Currently: I'm trying to design an application which parses a file with custom syntax into a slideshow which can be serialized with `serde` into a binary format. I'd love to find a way to represent rich text in a generic way such that the parser doesn't have to pull in any GUI or text shaping libraries to represent it, This library would be a perfect fit, if it had `serde` support.

I understand that this library is supposed to be dependency-less by default, but I think that adding just the option would add a lot of value to this already excellent library